### PR TITLE
Updates to single glmnet procedure

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -19,6 +19,8 @@ index_first_copy <- function(X) {
 #' @param X Sparse matrix containing columns of indicator functions.
 #' @param copy_map the copy map
 #'
+#' @export
+#'
 apply_copy_map <- function(X, copy_map) {
     .Call('_hal9001_apply_copy_map', PACKAGE = 'hal9001', X, copy_map)
 }
@@ -76,6 +78,8 @@ evaluate_basis <- function(basis, X, x_basis, basis_col) {
 #'
 #' @param X Matrix of covariates containing observed data in the columns.
 #' @param blist List of basis functions with which to build HAL design matrix.
+#'
+#' @export
 #'
 make_design_matrix <- function(X, blist) {
     .Call('_hal9001_make_design_matrix', PACKAGE = 'hal9001', X, blist)

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -15,8 +15,10 @@ index_first_copy <- function(X) {
 #' Apply copy map
 #'
 #' OR duplicate training set columns together
+#'
 #' @param X Sparse matrix containing columns of indicator functions.
 #' @param copy_map the copy map
+#'
 apply_copy_map <- function(X, copy_map) {
     .Call('_hal9001_apply_copy_map', PACKAGE = 'hal9001', X, copy_map)
 }

--- a/R/hal.R
+++ b/R/hal.R
@@ -36,7 +36,7 @@
 #'  generalized linear model. Options are limited to "gaussian" for fitting a
 #'  standard general linear model and "binomial" for logistic regression.
 #' @param return_lasso A \code{logical} indicating whether or not to return
-#' the HAL lasso fit.
+#'  the \code{glmnet} fit of the lasso model.
 #' @param return_x_basis A \code{logical} indicating whether or not to return
 #' the matrix of (possibly reduced) basis functions used in the HAL lasso fit.
 #' @param basis_list The full set of basis functions generated from the input
@@ -45,8 +45,13 @@
 #'  and d is the number of columns in X.
 #' @param lambda A user-specified array of values of the lambda tuning parameter
 #'  of the Lasso L1 regression. If \code{NULL}, \code{cv.glmnet} will be used to
-#'  automatically select a CV-optimal value of this parameter. If specified, the
-#'  Lasso L1 regression model will be fit via \code{glmnet}.
+#'  automatically select a CV-optimal value of this regularization parameter. If
+#'  specified, the Lasso L1 regression model will be fit via \code{glmnet},
+#'  returning regularized coefficient values for each value in the input array.
+#' @param fit_glmnet A \code{logical} specifying whether the array of values
+#'  specified should be passed to \code{cv.glmnet} in order to pick the optimal
+#'  value (based on cross-validation) (when set to \code{FALSE}) or to simply
+#'  fit along the sequence of values (or single value) using \code{glmnet}.
 #' @param ... Other arguments passed to \code{cv.glmnet}. Please consult the
 #'  documentation for \code{glmnet} for a full list of options.
 #' @param yolo A \code{logical} indicating whether to print one of a curated
@@ -74,6 +79,7 @@ fit_hal <- function(X,
                     return_x_basis = FALSE,
                     basis_list = NULL,
                     lambda = NULL,
+                    fit_glmnet = FALSE,
                     ...,
                     yolo = TRUE) {
   # check arguments and catch function call
@@ -89,13 +95,6 @@ fit_hal <- function(X,
   # cast X to matrix -- and don't start the timer until after
   if (!is.matrix(X)) {
     X <- as.matrix(X)
-  }
-
-  # set boolean for later use in fitting Lasso model via glmnet
-  if (!is.null(lambda) & length(lambda) == 1) {
-    fit_single_lambda <- TRUE
-  } else {
-    fit_single_lambda <- FALSE
   }
 
   # FUN! Quotes from HAL 9000, the robot from the film "2001: A Space Odyssey"
@@ -142,7 +141,7 @@ fit_hal <- function(X,
     }
   } else if (fit_type == "glmnet") {
     # just use the standard implementation available in glmnet
-    if (fit_single_lambda) {
+    if (fit_glmnet) {
       hal_lasso <- glmnet::glmnet(
         x = x_basis,
         y = Y,
@@ -188,8 +187,9 @@ fit_hal <- function(X,
 
   # glmnet_lasso records the best glmnet object
   glmnet_lasso <- NULL
-  if (fit_single_lambda & return_lasso) glmnet_lasso <- hal_lasso
-  if (!fit_single_lambda & return_lasso) glmnet_lasso <- hal_lasso$glmnet.fit
+  if (fit_glmnet & return_lasso) glmnet_lasso <- hal_lasso
+  if (!fit_glmnet & return_lasso) glmnet_lasso <- hal_lasso$glmnet.fit
+
   # construct output object with S3
   fit <- list(
     call = call,
@@ -206,7 +206,7 @@ fit_hal <- function(X,
     lambda_star = lambda_star,
     family = family,
     hal_lasso =
-      if (return_lasso & !fit_single_lambda) {
+      if (return_lasso & !fit_glmnet) {
         hal_lasso
       } else {
         NULL

--- a/R/hal.R
+++ b/R/hal.R
@@ -48,10 +48,11 @@
 #'  automatically select a CV-optimal value of this regularization parameter. If
 #'  specified, the Lasso L1 regression model will be fit via \code{glmnet},
 #'  returning regularized coefficient values for each value in the input array.
-#' @param fit_glmnet A \code{logical} specifying whether the array of values
+#' @param cv_select A \code{logical} specifying whether the array of values
 #'  specified should be passed to \code{cv.glmnet} in order to pick the optimal
-#'  value (based on cross-validation) (when set to \code{FALSE}) or to simply
-#'  fit along the sequence of values (or single value) using \code{glmnet}.
+#'  value (based on cross-validation) (when set to \code{TRUE}) or to simply
+#'  fit along the sequence of values (or single value) using \code{glmnet} (when
+#'  set to \code{FALSE}).
 #' @param ... Other arguments passed to \code{cv.glmnet}. Please consult the
 #'  documentation for \code{glmnet} for a full list of options.
 #' @param yolo A \code{logical} indicating whether to print one of a curated
@@ -79,7 +80,7 @@ fit_hal <- function(X,
                     return_x_basis = FALSE,
                     basis_list = NULL,
                     lambda = NULL,
-                    fit_glmnet = FALSE,
+                    cv_select = TRUE,
                     ...,
                     yolo = TRUE) {
   # check arguments and catch function call
@@ -141,7 +142,7 @@ fit_hal <- function(X,
     }
   } else if (fit_type == "glmnet") {
     # just use the standard implementation available in glmnet
-    if (fit_glmnet) {
+    if (!cv_select) {
       hal_lasso <- glmnet::glmnet(
         x = x_basis,
         y = Y,
@@ -187,8 +188,8 @@ fit_hal <- function(X,
 
   # glmnet_lasso records the best glmnet object
   glmnet_lasso <- NULL
-  if (fit_glmnet & return_lasso) glmnet_lasso <- hal_lasso
-  if (!fit_glmnet & return_lasso) glmnet_lasso <- hal_lasso$glmnet.fit
+  if (!cv_select & return_lasso) glmnet_lasso <- hal_lasso
+  if (cv_select & return_lasso) glmnet_lasso <- hal_lasso$glmnet.fit
 
   # construct output object with S3
   fit <- list(
@@ -206,7 +207,7 @@ fit_hal <- function(X,
     lambda_star = lambda_star,
     family = family,
     hal_lasso =
-      if (return_lasso & !fit_glmnet) {
+      if (return_lasso & cv_select) {
         hal_lasso
       } else {
         NULL

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Laan (2016) and van der Laan (2017a).
 # load the hal9001 package
 library(hal9001)
 #> Loading required package: Rcpp
-#> hal9001 v0.2.0: The Scalable Highly Adaptive Lasso
+#> hal9001 v0.2.1: The Scalable Highly Adaptive Lasso
 
 # simulate data
 set.seed(385971)
@@ -100,11 +100,11 @@ hal_fit <- fit_hal(X = x, Y = y)
 #> [1] "Look Dave, I can see you're really upset about this. I honestly think you ought to sit down calmly, take a stress pill, and think things over."
 hal_fit$times
 #>                   user.self sys.self elapsed user.child sys.child
-#> design_matrix         0.002    0.001   0.003          0         0
-#> remove_duplicates     0.004    0.000   0.004          0         0
+#> design_matrix         0.000    0.003   0.002          0         0
+#> remove_duplicates     0.003    0.001   0.005          0         0
 #> reduce_basis          0.000    0.000   0.000          0         0
-#> lasso                 0.279    0.000   0.279          0         0
-#> total                 0.285    0.001   0.286          0         0
+#> lasso                 0.260    0.000   0.260          0         0
+#> total                 0.263    0.004   0.267          0         0
 
 # training sample prediction
 preds <- predict(hal_fit, new_data = x)

--- a/README.md
+++ b/README.md
@@ -100,11 +100,11 @@ hal_fit <- fit_hal(X = x, Y = y)
 #> [1] "Look Dave, I can see you're really upset about this. I honestly think you ought to sit down calmly, take a stress pill, and think things over."
 hal_fit$times
 #>                   user.self sys.self elapsed user.child sys.child
-#> design_matrix         0.000    0.003   0.002          0         0
-#> remove_duplicates     0.003    0.001   0.005          0         0
+#> design_matrix         0.008    0.000   0.008          0         0
+#> remove_duplicates     0.011    0.000   0.011          0         0
 #> reduce_basis          0.000    0.000   0.000          0         0
-#> lasso                 0.260    0.000   0.260          0         0
-#> total                 0.263    0.004   0.267          0         0
+#> lasso                 0.255    0.008   0.264          0         0
+#> total                 0.274    0.008   0.283          0         0
 
 # training sample prediction
 preds <- predict(hal_fit, new_data = x)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,7 +10,7 @@ install:
   ps: Bootstrap
 
 cache:
-  - C:\RLibrary -> appveyor.yml
+  - C:\RLibrary
 
 # Adapt as necessary starting from here
 branches:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,7 +10,7 @@ install:
   ps: Bootstrap
 
 cache:
-  - C:\RLibrary
+  - C:\RLibrary -> appveyor.yml
 
 # Adapt as necessary starting from here
 branches:

--- a/docs/LICENSE-text.html
+++ b/docs/LICENSE-text.html
@@ -800,7 +800,7 @@ Public License instead of this License.  But first, please read
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.2.0.</p>
+  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.3.0.</p>
 </div>
       </footer>
    </div>

--- a/docs/articles/index.html
+++ b/docs/articles/index.html
@@ -129,7 +129,7 @@
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.2.0.</p>
+  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.3.0.</p>
 </div>
       </footer>
    </div>

--- a/docs/articles/intro_hal9001.html
+++ b/docs/articles/intro_hal9001.html
@@ -80,7 +80,7 @@
 <a href="https://nimahejazi.org">Nima Hejazi</a> and <a href="https://github.com/jeremyrcoyle">Jeremy Coyle</a>
 </h4>
             
-            <h4 class="date">2018-12-04</h4>
+            <h4 class="date">2018-12-20</h4>
       
       <small class="dont-index">Source: <a href="https://github.com/tlverse/hal9001/blob/master/vignettes/intro_hal9001.Rmd"><code>vignettes/intro_hal9001.Rmd</code></a></small>
       <div class="hidden name"><code>intro_hal9001.Rmd</code></div>
@@ -144,7 +144,7 @@
 <a href="#using-the-highly-adaptive-lasso" class="anchor"></a>Using the Highly Adaptive LASSO</h2>
 <div class="sourceCode" id="cb9"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb9-1" data-line-number="1"><span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/library">library</a></span>(hal9001)</a></code></pre></div>
 <pre><code>## Loading required package: Rcpp</code></pre>
-<pre><code>## hal9001 v0.2.0: The Scalable Highly Adaptive Lasso</code></pre>
+<pre><code>## hal9001 v0.2.1: The Scalable Highly Adaptive Lasso</code></pre>
 <div id="fitting-the-hal-model-lassi" class="section level3">
 <h3 class="hasAnchor">
 <a href="#fitting-the-hal-model-lassi" class="anchor"></a>Fitting the HAL model: “lassi”</h3>
@@ -153,14 +153,17 @@
 <pre><code>## [1] "Good afternoon... gentlemen. I am a HAL 9000... computer. I became operational at the H.A.L. plant in Urbana, Illinois... on the 12th of January 1992. My instructor was Mr. Langley... and he taught me to sing a song. If you'd like to hear it I can sing it for you."</code></pre>
 <div class="sourceCode" id="cb14"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb14-1" data-line-number="1">hal_fit1<span class="op">$</span>times</a></code></pre></div>
 <pre><code>##                   user.self sys.self elapsed user.child sys.child
-## design_matrix         0.114    0.019   0.133          0         0
-## remove_duplicates     0.179    0.004   0.183          0         0
+## design_matrix         0.109    0.024   0.134          0         0
+## remove_duplicates     0.175    0.012   0.186          0         0
 ## reduce_basis          0.000    0.000   0.000          0         0
-## lasso                 4.632    0.049   4.680          0         0
-## total                 4.925    0.072   4.996          0         0</code></pre>
+## lasso                 4.504    0.065   4.569          0         0
+## total                 4.788    0.101   4.889          0         0</code></pre>
 <div class="sourceCode" id="cb16"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb16-1" data-line-number="1">hal_fit1</a></code></pre></div>
 <pre><code>## $call
 ## fit_hal(X = x, Y = y, fit_type = "lassi")
+## 
+## $x_basis
+## NULL
 ## 
 ## $basis_list
 ## $basis_list[[1]]
@@ -78087,11 +78090,11 @@
 ## 
 ## $times
 ##                   user.self sys.self elapsed user.child sys.child
-## design_matrix         0.114    0.019   0.133          0         0
-## remove_duplicates     0.179    0.004   0.183          0         0
+## design_matrix         0.109    0.024   0.134          0         0
+## remove_duplicates     0.175    0.012   0.186          0         0
 ## reduce_basis          0.000    0.000   0.000          0         0
-## lasso                 4.632    0.049   4.680          0         0
-## total                 4.925    0.072   4.996          0         0
+## lasso                 4.504    0.065   4.569          0         0
+## total                 4.788    0.101   4.889          0         0
 ## 
 ## $lambda_star
 ## [1] 0.003284639
@@ -78100,6 +78103,9 @@
 ## [1] "gaussian"
 ## 
 ## $hal_lasso
+## NULL
+## 
+## $glmnet_lasso
 ## NULL
 ## 
 ## attr(,"class")
@@ -78114,14 +78120,17 @@
 <pre><code>## [1] "I've just picked up a fault in the AE35 unit. It's going to go 100% failure in 72 hours."</code></pre>
 <div class="sourceCode" id="cb20"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb20-1" data-line-number="1">hal_fit2<span class="op">$</span>times</a></code></pre></div>
 <pre><code>##                   user.self sys.self elapsed user.child sys.child
-## design_matrix         0.096    0.012   0.108          0         0
-## remove_duplicates     0.020    0.000   0.020          0         0
-## reduce_basis          0.000    0.000   0.000          0         0
-## lasso                 8.727    0.008   8.734          0         0
-## total                 8.843    0.020   8.862          0         0</code></pre>
+## design_matrix         0.102        0   0.102          0         0
+## remove_duplicates     0.018        0   0.018          0         0
+## reduce_basis          0.000        0   0.000          0         0
+## lasso                 8.557        0   8.557          0         0
+## total                 8.677        0   8.677          0         0</code></pre>
 <div class="sourceCode" id="cb22"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb22-1" data-line-number="1">hal_fit2</a></code></pre></div>
 <pre><code>## $call
 ## fit_hal(X = x, Y = y, fit_type = "glmnet")
+## 
+## $x_basis
+## NULL
 ## 
 ## $basis_list
 ## $basis_list[[1]]
@@ -161107,11 +161116,11 @@
 ## 
 ## $times
 ##                   user.self sys.self elapsed user.child sys.child
-## design_matrix         0.096    0.012   0.108          0         0
-## remove_duplicates     0.020    0.000   0.020          0         0
-## reduce_basis          0.000    0.000   0.000          0         0
-## lasso                 8.727    0.008   8.734          0         0
-## total                 8.843    0.020   8.862          0         0
+## design_matrix         0.102        0   0.102          0         0
+## remove_duplicates     0.018        0   0.018          0         0
+## reduce_basis          0.000        0   0.000          0         0
+## lasso                 8.557        0   8.557          0         0
+## total                 8.677        0   8.677          0         0
 ## 
 ## $lambda_star
 ## [1] 0.004955143
@@ -161120,6 +161129,9 @@
 ## [1] "gaussian"
 ## 
 ## $hal_lasso
+## NULL
+## 
+## $glmnet_lasso
 ## NULL
 ## 
 ## attr(,"class")
@@ -161135,15 +161147,18 @@
 <pre><code>## [1] "Just what do you think you're doing, Dave?"</code></pre>
 <div class="sourceCode" id="cb26"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb26-1" data-line-number="1">hal_fit3<span class="op">$</span>times</a></code></pre></div>
 <pre><code>##                   user.self sys.self elapsed user.child sys.child
-## design_matrix         0.107    0.000   0.108          0         0
-## remove_duplicates     0.020    0.000   0.020          0         0
-## reduce_basis          0.013    0.000   0.013          0         0
-## lasso                 4.181    0.004   4.184          0         0
-## total                 4.308    0.004   4.312          0         0</code></pre>
+## design_matrix         0.103    0.000   0.103          0         0
+## remove_duplicates     0.023    0.000   0.023          0         0
+## reduce_basis          0.013    0.000   0.014          0         0
+## lasso                 4.339    0.032   4.371          0         0
+## total                 4.465    0.032   4.497          0         0</code></pre>
 <p>In the above, all basis functions with fewer than 3.1622777% of observations meeting the criterion imposed are automatically removed prior to the Lasso step of fitting the HAL regression. The results appear below</p>
 <div class="sourceCode" id="cb28"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb28-1" data-line-number="1">hal_fit3</a></code></pre></div>
 <pre><code>## $call
 ## fit_hal(X = x, Y = y, fit_type = "lassi", reduce_basis = 1/sqrt(length(y)))
+## 
+## $x_basis
+## NULL
 ## 
 ## $basis_list
 ## $basis_list[[1]]
@@ -238894,11 +238909,11 @@
 ## 
 ## $times
 ##                   user.self sys.self elapsed user.child sys.child
-## design_matrix         0.107    0.000   0.108          0         0
-## remove_duplicates     0.020    0.000   0.020          0         0
-## reduce_basis          0.013    0.000   0.013          0         0
-## lasso                 4.181    0.004   4.184          0         0
-## total                 4.308    0.004   4.312          0         0
+## design_matrix         0.103    0.000   0.103          0         0
+## remove_duplicates     0.023    0.000   0.023          0         0
+## reduce_basis          0.013    0.000   0.014          0         0
+## lasso                 4.339    0.032   4.371          0         0
+## total                 4.465    0.032   4.497          0         0
 ## 
 ## $lambda_star
 ## [1] 0.003956359
@@ -238907,6 +238922,9 @@
 ## [1] "gaussian"
 ## 
 ## $hal_lasso
+## NULL
+## 
+## $glmnet_lasso
 ## NULL
 ## 
 ## attr(,"class")
@@ -238969,7 +238987,7 @@
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.2.0.</p>
+  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.3.0.</p>
 </div>
       </footer>
 </div>

--- a/docs/articles/intro_hal9001.html
+++ b/docs/articles/intro_hal9001.html
@@ -80,7 +80,7 @@
 <a href="https://nimahejazi.org">Nima Hejazi</a> and <a href="https://github.com/jeremyrcoyle">Jeremy Coyle</a>
 </h4>
             
-            <h4 class="date">2018-12-20</h4>
+            <h4 class="date">2019-02-16</h4>
       
       <small class="dont-index">Source: <a href="https://github.com/tlverse/hal9001/blob/master/vignettes/intro_hal9001.Rmd"><code>vignettes/intro_hal9001.Rmd</code></a></small>
       <div class="hidden name"><code>intro_hal9001.Rmd</code></div>
@@ -92,15 +92,7 @@
 <div id="introduction" class="section level2">
 <h2 class="hasAnchor">
 <a href="#introduction" class="anchor"></a>Introduction</h2>
-<p>The <em>highly adaptive LASSO</em> (HAL) is a flexible machine learning algorithm that nonparametrically estimates a function based on available data by embedding a set of input observations and covariates in an extremely high-dimensional space (i.e., generating basis functions from the available data). For an input data matrix of <span class="math inline">\(n\)</span> observations and <span class="math inline">\(d\)</span> covariates, the number of basis functions generated is approximately <span class="math inline">\(n \cdot 2^{d - 1}\)</span>. To select a set of basis functions from among the full set generated, the LASSO is employed. The <code>hal9001</code> R package provides an efficient implementation of this routine, relying on the <code>glmnet</code> R package for compatibility with the canonical LASSO implementation while still providing a (faster) custom C++ routine for using the LASSO with an input matrix composed of indicator functions. Consider consulting the following references for more detailed descriptions of HAL:</p>
-<ol style="list-style-type: decimal">
-<li>
-<span class="citation">(Benkeser and van der Laan 2016)</span>,</li>
-<li>
-<span class="citation">(van der Laan 2015)</span>,</li>
-<li>
-<span class="citation">(van der Laan 2017)</span>.</li>
-</ol>
+<p>The <em>highly adaptive Lasso</em> (HAL) is a flexible machine learning algorithm that nonparametrically estimates a function based on available data by embedding a set of input observations and covariates in an extremely high-dimensional space (i.e., generating basis functions from the available data). For an input data matrix of <span class="math inline">\(n\)</span> observations and <span class="math inline">\(d\)</span> covariates, the number of basis functions generated is approximately <span class="math inline">\(n \cdot 2^{d - 1}\)</span>. To select a set of basis functions from among the full set generated, the Lasso is employed. The <code>hal9001</code> R package provides an efficient implementation of this routine, relying on the <code>glmnet</code> R package for compatibility with the canonical Lasso implementation while still providing a (faster) custom C++ routine for using the Lasso with an input matrix composed of indicator functions. Consider consulting <span class="citation">Benkeser and van der Laan (2016)</span>, <span class="citation">van der Laan (2015)</span>, <span class="citation">van der Laan (2017)</span> for detailed theoretical descriptions of the highly adaptive Lasso and its various optimality properties.</p>
 <hr>
 </div>
 <div id="preliminaries" class="section level2">
@@ -141,7 +133,7 @@
 </div>
 <div id="using-the-highly-adaptive-lasso" class="section level2">
 <h2 class="hasAnchor">
-<a href="#using-the-highly-adaptive-lasso" class="anchor"></a>Using the Highly Adaptive LASSO</h2>
+<a href="#using-the-highly-adaptive-lasso" class="anchor"></a>Using the Highly Adaptive Lasso</h2>
 <div class="sourceCode" id="cb9"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb9-1" data-line-number="1"><span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/library">library</a></span>(hal9001)</a></code></pre></div>
 <pre><code>## Loading required package: Rcpp</code></pre>
 <pre><code>## hal9001 v0.2.1: The Scalable Highly Adaptive Lasso</code></pre>
@@ -153,11 +145,11 @@
 <pre><code>## [1] "Good afternoon... gentlemen. I am a HAL 9000... computer. I became operational at the H.A.L. plant in Urbana, Illinois... on the 12th of January 1992. My instructor was Mr. Langley... and he taught me to sing a song. If you'd like to hear it I can sing it for you."</code></pre>
 <div class="sourceCode" id="cb14"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb14-1" data-line-number="1">hal_fit1<span class="op">$</span>times</a></code></pre></div>
 <pre><code>##                   user.self sys.self elapsed user.child sys.child
-## design_matrix         0.109    0.024   0.134          0         0
-## remove_duplicates     0.175    0.012   0.186          0         0
+## design_matrix         0.114    0.020   0.134          0         0
+## remove_duplicates     0.184    0.003   0.188          0         0
 ## reduce_basis          0.000    0.000   0.000          0         0
-## lasso                 4.504    0.065   4.569          0         0
-## total                 4.788    0.101   4.889          0         0</code></pre>
+## lasso                 4.546    0.046   4.593          0         0
+## total                 4.844    0.069   4.915          0         0</code></pre>
 <div class="sourceCode" id="cb16"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb16-1" data-line-number="1">hal_fit1</a></code></pre></div>
 <pre><code>## $call
 ## fit_hal(X = x, Y = y, fit_type = "lassi")
@@ -78090,11 +78082,11 @@
 ## 
 ## $times
 ##                   user.self sys.self elapsed user.child sys.child
-## design_matrix         0.109    0.024   0.134          0         0
-## remove_duplicates     0.175    0.012   0.186          0         0
+## design_matrix         0.114    0.020   0.134          0         0
+## remove_duplicates     0.184    0.003   0.188          0         0
 ## reduce_basis          0.000    0.000   0.000          0         0
-## lasso                 4.504    0.065   4.569          0         0
-## total                 4.788    0.101   4.889          0         0
+## lasso                 4.546    0.046   4.593          0         0
+## total                 4.844    0.069   4.915          0         0
 ## 
 ## $lambda_star
 ## [1] 0.003284639
@@ -78120,11 +78112,11 @@
 <pre><code>## [1] "I've just picked up a fault in the AE35 unit. It's going to go 100% failure in 72 hours."</code></pre>
 <div class="sourceCode" id="cb20"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb20-1" data-line-number="1">hal_fit2<span class="op">$</span>times</a></code></pre></div>
 <pre><code>##                   user.self sys.self elapsed user.child sys.child
-## design_matrix         0.102        0   0.102          0         0
-## remove_duplicates     0.018        0   0.018          0         0
-## reduce_basis          0.000        0   0.000          0         0
-## lasso                 8.557        0   8.557          0         0
-## total                 8.677        0   8.677          0         0</code></pre>
+## design_matrix         0.105    0.000   0.105          0         0
+## remove_duplicates     0.022    0.002   0.024          0         0
+## reduce_basis          0.000    0.000   0.000          0         0
+## lasso                 8.495    0.007   8.506          0         0
+## total                 8.622    0.009   8.635          0         0</code></pre>
 <div class="sourceCode" id="cb22"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb22-1" data-line-number="1">hal_fit2</a></code></pre></div>
 <pre><code>## $call
 ## fit_hal(X = x, Y = y, fit_type = "glmnet")
@@ -161116,11 +161108,11 @@
 ## 
 ## $times
 ##                   user.self sys.self elapsed user.child sys.child
-## design_matrix         0.102        0   0.102          0         0
-## remove_duplicates     0.018        0   0.018          0         0
-## reduce_basis          0.000        0   0.000          0         0
-## lasso                 8.557        0   8.557          0         0
-## total                 8.677        0   8.677          0         0
+## design_matrix         0.105    0.000   0.105          0         0
+## remove_duplicates     0.022    0.002   0.024          0         0
+## reduce_basis          0.000    0.000   0.000          0         0
+## lasso                 8.495    0.007   8.506          0         0
+## total                 8.622    0.009   8.635          0         0
 ## 
 ## $lambda_star
 ## [1] 0.004955143
@@ -161147,11 +161139,11 @@
 <pre><code>## [1] "Just what do you think you're doing, Dave?"</code></pre>
 <div class="sourceCode" id="cb26"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb26-1" data-line-number="1">hal_fit3<span class="op">$</span>times</a></code></pre></div>
 <pre><code>##                   user.self sys.self elapsed user.child sys.child
-## design_matrix         0.103    0.000   0.103          0         0
-## remove_duplicates     0.023    0.000   0.023          0         0
-## reduce_basis          0.013    0.000   0.014          0         0
-## lasso                 4.339    0.032   4.371          0         0
-## total                 4.465    0.032   4.497          0         0</code></pre>
+## design_matrix         0.104    0.000   0.104          0         0
+## remove_duplicates     0.019    0.000   0.019          0         0
+## reduce_basis          0.018    0.000   0.018          0         0
+## lasso                 4.334    0.004   4.340          0         0
+## total                 4.457    0.004   4.463          0         0</code></pre>
 <p>In the above, all basis functions with fewer than 3.1622777% of observations meeting the criterion imposed are automatically removed prior to the Lasso step of fitting the HAL regression. The results appear below</p>
 <div class="sourceCode" id="cb28"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb28-1" data-line-number="1">hal_fit3</a></code></pre></div>
 <pre><code>## $call
@@ -238909,11 +238901,11 @@
 ## 
 ## $times
 ##                   user.self sys.self elapsed user.child sys.child
-## design_matrix         0.103    0.000   0.103          0         0
-## remove_duplicates     0.023    0.000   0.023          0         0
-## reduce_basis          0.013    0.000   0.014          0         0
-## lasso                 4.339    0.032   4.371          0         0
-## total                 4.465    0.032   4.497          0         0
+## design_matrix         0.104    0.000   0.104          0         0
+## remove_duplicates     0.019    0.000   0.019          0         0
+## reduce_basis          0.018    0.000   0.018          0         0
+## lasso                 4.334    0.004   4.340          0         0
+## total                 4.457    0.004   4.463          0         0
 ## 
 ## $lambda_star
 ## [1] 0.003956359
@@ -238973,7 +238965,7 @@
       <ul class="nav nav-pills nav-stacked">
 <li><a href="#introduction">Introduction</a></li>
       <li><a href="#preliminaries">Preliminaries</a></li>
-      <li><a href="#using-the-highly-adaptive-lasso">Using the Highly Adaptive LASSO</a></li>
+      <li><a href="#using-the-highly-adaptive-lasso">Using the Highly Adaptive Lasso</a></li>
       <li><a href="#references">References</a></li>
       </ul>
 </div>

--- a/docs/authors.html
+++ b/docs/authors.html
@@ -146,7 +146,7 @@
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.2.0.</p>
+  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.3.0.</p>
 </div>
       </footer>
    </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -142,11 +142,11 @@ install.packages("hal9001")
 <a class="sourceLine" id="cb2-15" data-line-number="15"><span class="co">#&gt; [1] "Look Dave, I can see you're really upset about this. I honestly think you ought to sit down calmly, take a stress pill, and think things over."</span></a>
 <a class="sourceLine" id="cb2-16" data-line-number="16">hal_fit<span class="op">$</span>times</a>
 <a class="sourceLine" id="cb2-17" data-line-number="17"><span class="co">#&gt;                   user.self sys.self elapsed user.child sys.child</span></a>
-<a class="sourceLine" id="cb2-18" data-line-number="18"><span class="co">#&gt; design_matrix         0.002    0.001   0.003          0         0</span></a>
+<a class="sourceLine" id="cb2-18" data-line-number="18"><span class="co">#&gt; design_matrix         0.002    0.001   0.002          0         0</span></a>
 <a class="sourceLine" id="cb2-19" data-line-number="19"><span class="co">#&gt; remove_duplicates     0.004    0.000   0.005          0         0</span></a>
 <a class="sourceLine" id="cb2-20" data-line-number="20"><span class="co">#&gt; reduce_basis          0.000    0.000   0.000          0         0</span></a>
-<a class="sourceLine" id="cb2-21" data-line-number="21"><span class="co">#&gt; lasso                 0.250    0.008   0.257          0         0</span></a>
-<a class="sourceLine" id="cb2-22" data-line-number="22"><span class="co">#&gt; total                 0.256    0.009   0.265          0         0</span></a>
+<a class="sourceLine" id="cb2-21" data-line-number="21"><span class="co">#&gt; lasso                 0.252    0.008   0.259          0         0</span></a>
+<a class="sourceLine" id="cb2-22" data-line-number="22"><span class="co">#&gt; total                 0.258    0.009   0.266          0         0</span></a>
 <a class="sourceLine" id="cb2-23" data-line-number="23"></a>
 <a class="sourceLine" id="cb2-24" data-line-number="24"><span class="co"># training sample prediction</span></a>
 <a class="sourceLine" id="cb2-25" data-line-number="25">preds &lt;-<span class="st"> </span><span class="kw"><a href="https://www.rdocumentation.org/packages/stats/topics/predict">predict</a></span>(hal_fit, <span class="dt">new_data =</span> x)</a>

--- a/docs/index.html
+++ b/docs/index.html
@@ -28,7 +28,7 @@
 </script>
 </head>
 <body>
-    <div class="container template-home">
+    <div class="container template-article">
       <header><div class="navbar navbar-default navbar-fixed-top" role="navigation">
   <div class="container">
     <div class="navbar-header">
@@ -76,7 +76,11 @@
 
       
       </header><div class="row">
-  <div class="contents col-md-9">
+  <div class="col-md-9 contents">
+    
+
+    
+    
 <!-- README.md is generated from README.Rmd. Please edit that file -->
 <div id="rhal9001" class="section level1">
 <div class="page-header"><h1 class="hasAnchor">
@@ -124,7 +128,7 @@ install.packages("hal9001")
 <div class="sourceCode" id="cb2"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb2-1" data-line-number="1"><span class="co"># load the hal9001 package</span></a>
 <a class="sourceLine" id="cb2-2" data-line-number="2"><span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/library">library</a></span>(hal9001)</a>
 <a class="sourceLine" id="cb2-3" data-line-number="3"><span class="co">#&gt; Loading required package: Rcpp</span></a>
-<a class="sourceLine" id="cb2-4" data-line-number="4"><span class="co">#&gt; hal9001 v0.2.0: The Scalable Highly Adaptive Lasso</span></a>
+<a class="sourceLine" id="cb2-4" data-line-number="4"><span class="co">#&gt; hal9001 v0.2.1: The Scalable Highly Adaptive Lasso</span></a>
 <a class="sourceLine" id="cb2-5" data-line-number="5"></a>
 <a class="sourceLine" id="cb2-6" data-line-number="6"><span class="co"># simulate data</span></a>
 <a class="sourceLine" id="cb2-7" data-line-number="7"><span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/Random">set.seed</a></span>(<span class="dv">385971</span>)</a>
@@ -138,11 +142,11 @@ install.packages("hal9001")
 <a class="sourceLine" id="cb2-15" data-line-number="15"><span class="co">#&gt; [1] "Look Dave, I can see you're really upset about this. I honestly think you ought to sit down calmly, take a stress pill, and think things over."</span></a>
 <a class="sourceLine" id="cb2-16" data-line-number="16">hal_fit<span class="op">$</span>times</a>
 <a class="sourceLine" id="cb2-17" data-line-number="17"><span class="co">#&gt;                   user.self sys.self elapsed user.child sys.child</span></a>
-<a class="sourceLine" id="cb2-18" data-line-number="18"><span class="co">#&gt; design_matrix         0.003    0.000   0.003          0         0</span></a>
-<a class="sourceLine" id="cb2-19" data-line-number="19"><span class="co">#&gt; remove_duplicates     0.004    0.000   0.004          0         0</span></a>
+<a class="sourceLine" id="cb2-18" data-line-number="18"><span class="co">#&gt; design_matrix         0.002    0.001   0.003          0         0</span></a>
+<a class="sourceLine" id="cb2-19" data-line-number="19"><span class="co">#&gt; remove_duplicates     0.004    0.000   0.005          0         0</span></a>
 <a class="sourceLine" id="cb2-20" data-line-number="20"><span class="co">#&gt; reduce_basis          0.000    0.000   0.000          0         0</span></a>
-<a class="sourceLine" id="cb2-21" data-line-number="21"><span class="co">#&gt; lasso                 0.252    0.004   0.257          0         0</span></a>
-<a class="sourceLine" id="cb2-22" data-line-number="22"><span class="co">#&gt; total                 0.259    0.004   0.264          0         0</span></a>
+<a class="sourceLine" id="cb2-21" data-line-number="21"><span class="co">#&gt; lasso                 0.250    0.008   0.257          0         0</span></a>
+<a class="sourceLine" id="cb2-22" data-line-number="22"><span class="co">#&gt; total                 0.256    0.009   0.265          0         0</span></a>
 <a class="sourceLine" id="cb2-23" data-line-number="23"></a>
 <a class="sourceLine" id="cb2-24" data-line-number="24"><span class="co"># training sample prediction</span></a>
 <a class="sourceLine" id="cb2-25" data-line-number="25">preds &lt;-<span class="st"> </span><span class="kw"><a href="https://www.rdocumentation.org/packages/stats/topics/predict">predict</a></span>(hal_fit, <span class="dt">new_data =</span> x)</a>
@@ -195,7 +199,7 @@ install.packages("hal9001")
 </div>
   </div>
 
-  <div class="col-md-3" id="sidebar">
+  <div class="col-md-3 hidden-xs hidden-sm" id="sidebar">
     <div class="links">
 <h2>Links</h2>
 <ul class="list-unstyled">
@@ -221,7 +225,7 @@ install.packages("hal9001")
 </ul>
 </div>
 
-  <div class="dev-status">
+      <div class="dev-status">
 <h2>Dev status</h2>
 <ul class="list-unstyled">
 <li><a href="https://travis-ci.org/tlverse/hal9001"><img src="https://travis-ci.org/tlverse/hal9001.svg?branch=master" alt="Travis-CI Build Status"></a></li>
@@ -232,6 +236,7 @@ install.packages("hal9001")
 </ul>
 </div>
 </div>
+
 </div>
 
 
@@ -240,7 +245,7 @@ install.packages("hal9001")
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.2.0.</p>
+  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.3.0.</p>
 </div>
       </footer>
 </div>

--- a/docs/pkgdown.css
+++ b/docs/pkgdown.css
@@ -65,7 +65,7 @@ summary {
 
 /* Typographic tweaking ---------------------------------*/
 
-.contents h1.page-header {
+.contents .page-header {
   margin-top: calc(-60px + 1em);
 }
 

--- a/docs/pkgdown.js
+++ b/docs/pkgdown.js
@@ -25,6 +25,10 @@
     for (var i = 0; i < links.length; i++) {
       if (links[i].getAttribute("href") === "#")
         continue;
+      // Ignore external links
+      if (links[i].host !== location.host)
+        continue;
+
       var nav_path = paths(links[i].pathname);
 
       var length = prefix_length(nav_path, cur_path);
@@ -52,13 +56,14 @@
     return(pieces);
   }
 
+  // Returns -1 if not found
   function prefix_length(needle, haystack) {
     if (needle.length > haystack.length)
-      return(0);
+      return(-1);
 
     // Special case for length-0 haystack, since for loop won't run
     if (haystack.length === 0) {
-      return(needle.length === 0 ? 1 : 0);
+      return(needle.length === 0 ? 0 : -1);
     }
 
     for (var i = 0; i < haystack.length; i++) {

--- a/docs/pkgdown.yml
+++ b/docs/pkgdown.yml
@@ -1,5 +1,5 @@
 pandoc: 2.2.1
-pkgdown: 1.2.0
+pkgdown: 1.3.0
 pkgdown_sha: ~
 articles:
   intro_hal9001: intro_hal9001.html

--- a/docs/reference/SL.hal9001.html
+++ b/docs/reference/SL.hal9001.html
@@ -202,7 +202,7 @@ or <code>glmnet</code> through the <code>...</code> argument of <code>fit_hal</c
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.2.0.</p>
+  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.3.0.</p>
 </div>
       </footer>
    </div>

--- a/docs/reference/apply_copy_map.html
+++ b/docs/reference/apply_copy_map.html
@@ -155,7 +155,7 @@
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.2.0.</p>
+  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.3.0.</p>
 </div>
       </footer>
    </div>

--- a/docs/reference/as_dgCMatrix.html
+++ b/docs/reference/as_dgCMatrix.html
@@ -162,7 +162,7 @@ suitable for coercion to a sparse matrix format of <code>dgCMatrix</code>.</p></
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.2.0.</p>
+  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.3.0.</p>
 </div>
       </footer>
    </div>

--- a/docs/reference/basis_list_cols.html
+++ b/docs/reference/basis_list_cols.html
@@ -159,7 +159,7 @@ in the columns. Basis functions are computed for these covariates.</p></td>
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.2.0.</p>
+  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.3.0.</p>
 </div>
       </footer>
    </div>

--- a/docs/reference/basis_of_degree.html
+++ b/docs/reference/basis_of_degree.html
@@ -158,7 +158,7 @@ generating basis functions for the full dimensionality of the input matrix.</p><
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.2.0.</p>
+  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.3.0.</p>
 </div>
       </footer>
    </div>

--- a/docs/reference/cv_lasso.html
+++ b/docs/reference/cv_lasso.html
@@ -175,7 +175,7 @@ slower, but matches the <code>glmnet</code> implementation. Default <code>FALSE<
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.2.0.</p>
+  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.3.0.</p>
 </div>
       </footer>
    </div>

--- a/docs/reference/cv_lasso_early_stopping.html
+++ b/docs/reference/cv_lasso_early_stopping.html
@@ -170,7 +170,7 @@ the cross-validation procedure to select an optimal value of lambda.</p></td>
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.2.0.</p>
+  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.3.0.</p>
 </div>
       </footer>
    </div>

--- a/docs/reference/enumerate_basis.html
+++ b/docs/reference/enumerate_basis.html
@@ -160,7 +160,7 @@ generating basis functions for the full dimensionality of the input matrix.</p><
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.2.0.</p>
+  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.3.0.</p>
 </div>
       </footer>
    </div>

--- a/docs/reference/evaluate_basis.html
+++ b/docs/reference/evaluate_basis.html
@@ -163,7 +163,7 @@
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.2.0.</p>
+  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.3.0.</p>
 </div>
       </footer>
    </div>

--- a/docs/reference/fit_hal.html
+++ b/docs/reference/fit_hal.html
@@ -125,9 +125,9 @@
 
     <pre class="usage"><span class='fu'>fit_hal</span>(<span class='no'>X</span>, <span class='no'>Y</span>, <span class='kw'>degrees</span> <span class='kw'>=</span> <span class='kw'>NULL</span>, <span class='kw'>fit_type</span> <span class='kw'>=</span> <span class='fu'><a href='https://www.rdocumentation.org/packages/base/topics/c'>c</a></span>(<span class='st'>"glmnet"</span>, <span class='st'>"lassi"</span>),
   <span class='kw'>n_folds</span> <span class='kw'>=</span> <span class='fl'>10</span>, <span class='kw'>use_min</span> <span class='kw'>=</span> <span class='fl'>TRUE</span>, <span class='kw'>reduce_basis</span> <span class='kw'>=</span> <span class='kw'>NULL</span>,
-  <span class='kw'>family</span> <span class='kw'>=</span> <span class='fu'><a href='https://www.rdocumentation.org/packages/base/topics/c'>c</a></span>(<span class='st'>"gaussian"</span>, <span class='st'>"binomial"</span>), <span class='kw'>return_glmnet</span> <span class='kw'>=</span> <span class='fl'>FALSE</span>,
+  <span class='kw'>family</span> <span class='kw'>=</span> <span class='fu'><a href='https://www.rdocumentation.org/packages/base/topics/c'>c</a></span>(<span class='st'>"gaussian"</span>, <span class='st'>"binomial"</span>), <span class='kw'>return_lasso</span> <span class='kw'>=</span> <span class='fl'>FALSE</span>,
   <span class='kw'>return_x_basis</span> <span class='kw'>=</span> <span class='fl'>FALSE</span>, <span class='kw'>basis_list</span> <span class='kw'>=</span> <span class='kw'>NULL</span>, <span class='kw'>lambda</span> <span class='kw'>=</span> <span class='kw'>NULL</span>,
-  <span class='kw'>fit_cv_glmnet</span> <span class='kw'>=</span> <span class='fl'>FALSE</span>, <span class='no'>...</span>, <span class='kw'>yolo</span> <span class='kw'>=</span> <span class='fl'>TRUE</span>)</pre>
+  <span class='kw'>cv_select</span> <span class='kw'>=</span> <span class='fl'>TRUE</span>, <span class='no'>...</span>, <span class='kw'>yolo</span> <span class='kw'>=</span> <span class='fl'>TRUE</span>)</pre>
     
     <h2 class="hasAnchor" id="arguments"><a class="anchor" href="#arguments"></a>Arguments</h2>
     <table class="ref-arguments">
@@ -183,7 +183,7 @@ generalized linear model. Options are limited to "gaussian" for fitting a
 standard general linear model and "binomial" for logistic regression.</p></td>
     </tr>
     <tr>
-      <th>return_glmnet</th>
+      <th>return_lasso</th>
       <td><p>A <code>logical</code> indicating whether or not to return
 the <code>glmnet</code> fit of the lasso model.</p></td>
     </tr>
@@ -208,11 +208,12 @@ specified, the Lasso L1 regression model will be fit via <code>glmnet</code>,
 returning regularized coefficient values for each value in the input array.</p></td>
     </tr>
     <tr>
-      <th>fit_cv_glmnet</th>
+      <th>cv_select</th>
       <td><p>A <code>logical</code> specifying whether the array of values
 specified should be passed to <code>cv.glmnet</code> in order to pick the optimal
-value (based on cross-validation) (when set to <code>FALSE</code>) or to simply
-fit along the sequence of values using <code>glmnet</code>.</p></td>
+value (based on cross-validation) (when set to <code>TRUE</code>) or to simply
+fit along the sequence of values (or single value) using <code>glmnet</code> (when
+set to <code>FALSE</code>).</p></td>
     </tr>
     <tr>
       <th>...</th>

--- a/docs/reference/fit_hal.html
+++ b/docs/reference/fit_hal.html
@@ -125,9 +125,9 @@
 
     <pre class="usage"><span class='fu'>fit_hal</span>(<span class='no'>X</span>, <span class='no'>Y</span>, <span class='kw'>degrees</span> <span class='kw'>=</span> <span class='kw'>NULL</span>, <span class='kw'>fit_type</span> <span class='kw'>=</span> <span class='fu'><a href='https://www.rdocumentation.org/packages/base/topics/c'>c</a></span>(<span class='st'>"glmnet"</span>, <span class='st'>"lassi"</span>),
   <span class='kw'>n_folds</span> <span class='kw'>=</span> <span class='fl'>10</span>, <span class='kw'>use_min</span> <span class='kw'>=</span> <span class='fl'>TRUE</span>, <span class='kw'>reduce_basis</span> <span class='kw'>=</span> <span class='kw'>NULL</span>,
-  <span class='kw'>family</span> <span class='kw'>=</span> <span class='fu'><a href='https://www.rdocumentation.org/packages/base/topics/c'>c</a></span>(<span class='st'>"gaussian"</span>, <span class='st'>"binomial"</span>), <span class='kw'>return_lasso</span> <span class='kw'>=</span> <span class='fl'>FALSE</span>,
-  <span class='kw'>return_x_basis</span> <span class='kw'>=</span> <span class='fl'>FALSE</span>, <span class='kw'>basis_list</span> <span class='kw'>=</span> <span class='kw'>NULL</span>, <span class='kw'>lambda</span> <span class='kw'>=</span> <span class='kw'>NULL</span>, <span class='no'>...</span>,
-  <span class='kw'>yolo</span> <span class='kw'>=</span> <span class='fl'>TRUE</span>)</pre>
+  <span class='kw'>family</span> <span class='kw'>=</span> <span class='fu'><a href='https://www.rdocumentation.org/packages/base/topics/c'>c</a></span>(<span class='st'>"gaussian"</span>, <span class='st'>"binomial"</span>), <span class='kw'>return_glmnet</span> <span class='kw'>=</span> <span class='fl'>FALSE</span>,
+  <span class='kw'>return_x_basis</span> <span class='kw'>=</span> <span class='fl'>FALSE</span>, <span class='kw'>basis_list</span> <span class='kw'>=</span> <span class='kw'>NULL</span>, <span class='kw'>lambda</span> <span class='kw'>=</span> <span class='kw'>NULL</span>,
+  <span class='kw'>fit_cv_glmnet</span> <span class='kw'>=</span> <span class='fl'>FALSE</span>, <span class='no'>...</span>, <span class='kw'>yolo</span> <span class='kw'>=</span> <span class='fl'>TRUE</span>)</pre>
     
     <h2 class="hasAnchor" id="arguments"><a class="anchor" href="#arguments"></a>Arguments</h2>
     <table class="ref-arguments">
@@ -183,9 +183,9 @@ generalized linear model. Options are limited to "gaussian" for fitting a
 standard general linear model and "binomial" for logistic regression.</p></td>
     </tr>
     <tr>
-      <th>return_lasso</th>
+      <th>return_glmnet</th>
       <td><p>A <code>logical</code> indicating whether or not to return
-the HAL lasso fit.</p></td>
+the <code>glmnet</code> fit of the lasso model.</p></td>
     </tr>
     <tr>
       <th>return_x_basis</th>
@@ -203,8 +203,16 @@ and d is the number of columns in X.</p></td>
       <th>lambda</th>
       <td><p>A user-specified array of values of the lambda tuning parameter
 of the Lasso L1 regression. If <code>NULL</code>, <code>cv.glmnet</code> will be used to
-automatically select a CV-optimal value of this parameter. If specified, the
-Lasso L1 regression model will be fit via <code>glmnet</code>.</p></td>
+automatically select a CV-optimal value of this regularization parameter. If
+specified, the Lasso L1 regression model will be fit via <code>glmnet</code>,
+returning regularized coefficient values for each value in the input array.</p></td>
+    </tr>
+    <tr>
+      <th>fit_cv_glmnet</th>
+      <td><p>A <code>logical</code> specifying whether the array of values
+specified should be passed to <code>cv.glmnet</code> in order to pick the optimal
+value (based on cross-validation) (when set to <code>FALSE</code>) or to simply
+fit along the sequence of values using <code>glmnet</code>.</p></td>
     </tr>
     <tr>
       <th>...</th>
@@ -255,7 +263,7 @@ epic science-fiction film "2001: A Space Odyssey" (1968).</p></td>
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.2.0.</p>
+  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.3.0.</p>
 </div>
       </footer>
    </div>

--- a/docs/reference/hal9000.html
+++ b/docs/reference/hal9000.html
@@ -141,7 +141,7 @@
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.2.0.</p>
+  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.3.0.</p>
 </div>
       </footer>
    </div>

--- a/docs/reference/hal9001.html
+++ b/docs/reference/hal9001.html
@@ -140,7 +140,7 @@
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.2.0.</p>
+  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.3.0.</p>
 </div>
       </footer>
    </div>

--- a/docs/reference/hal_quotes.html
+++ b/docs/reference/hal_quotes.html
@@ -149,7 +149,7 @@ acclaimed epic science-fiction film "2001: A Space Odyssey" (1968).</p>
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.2.0.</p>
+  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.3.0.</p>
 </div>
       </footer>
    </div>

--- a/docs/reference/index.html
+++ b/docs/reference/index.html
@@ -296,7 +296,7 @@
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.2.0.</p>
+  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.3.0.</p>
 </div>
       </footer>
    </div>

--- a/docs/reference/index_first_copy.html
+++ b/docs/reference/index_first_copy.html
@@ -153,7 +153,7 @@ copy of that column</p>
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.2.0.</p>
+  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.3.0.</p>
 </div>
       </footer>
    </div>

--- a/docs/reference/lassi.html
+++ b/docs/reference/lassi.html
@@ -173,7 +173,7 @@
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.2.0.</p>
+  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.3.0.</p>
 </div>
       </footer>
    </div>

--- a/docs/reference/lassi_fit_module.html
+++ b/docs/reference/lassi_fit_module.html
@@ -140,7 +140,7 @@
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.2.0.</p>
+  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.3.0.</p>
 </div>
       </footer>
    </div>

--- a/docs/reference/lassi_origami.html
+++ b/docs/reference/lassi_origami.html
@@ -174,7 +174,7 @@ slower, but matches the <code>glmnet</code> implementation. Default <code>FALSE<
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.2.0.</p>
+  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.3.0.</p>
 </div>
       </footer>
    </div>

--- a/docs/reference/make_basis_list.html
+++ b/docs/reference/make_basis_list.html
@@ -164,7 +164,7 @@ equals cols.length() and each basis function is a list(cols, cutoffs).</p>
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.2.0.</p>
+  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.3.0.</p>
 </div>
       </footer>
    </div>

--- a/docs/reference/make_copy_map.html
+++ b/docs/reference/make_copy_map.html
@@ -152,7 +152,7 @@ covariates (X) and terms for interactions thereof.</p></td>
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.2.0.</p>
+  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.3.0.</p>
 </div>
       </footer>
    </div>

--- a/docs/reference/make_design_matrix.html
+++ b/docs/reference/make_design_matrix.html
@@ -157,7 +157,7 @@ basis functions in argument blist</p>
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.2.0.</p>
+  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.3.0.</p>
 </div>
       </footer>
    </div>

--- a/docs/reference/make_reduced_basis_map.html
+++ b/docs/reference/make_reduced_basis_map.html
@@ -173,7 +173,7 @@ HAL algorithm.</p></td>
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.2.0.</p>
+  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.3.0.</p>
 </div>
       </footer>
    </div>

--- a/docs/reference/meets_basis.html
+++ b/docs/reference/meets_basis.html
@@ -165,7 +165,7 @@ cols and cutoffs for a given row of X (X[row_num, ])</p>
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.2.0.</p>
+  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.3.0.</p>
 </div>
       </footer>
    </div>

--- a/docs/reference/predict.SL.hal9001.html
+++ b/docs/reference/predict.SL.hal9001.html
@@ -160,7 +160,7 @@
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.2.0.</p>
+  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.3.0.</p>
 </div>
       </footer>
    </div>

--- a/docs/reference/predict.hal9001.html
+++ b/docs/reference/predict.hal9001.html
@@ -172,7 +172,7 @@ compute predicted values.</p></td>
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.2.0.</p>
+  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.3.0.</p>
 </div>
       </footer>
    </div>

--- a/docs/reference/predict.lassi.html
+++ b/docs/reference/predict.lassi.html
@@ -160,7 +160,7 @@
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.2.0.</p>
+  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.3.0.</p>
 </div>
       </footer>
    </div>

--- a/docs/reference/squash_hal_fit.html
+++ b/docs/reference/squash_hal_fit.html
@@ -160,7 +160,7 @@ fitting the Highly Adaptive LASSO, as produced by a call to <code>fit_hal</code>
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.2.0.</p>
+  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.3.0.</p>
 </div>
       </footer>
    </div>

--- a/man/fit_hal.Rd
+++ b/man/fit_hal.Rd
@@ -8,7 +8,7 @@ fit_hal(X, Y, degrees = NULL, fit_type = c("glmnet", "lassi"),
   n_folds = 10, use_min = TRUE, reduce_basis = NULL,
   family = c("gaussian", "binomial"), return_lasso = FALSE,
   return_x_basis = FALSE, basis_list = NULL, lambda = NULL,
-  fit_glmnet = FALSE, ..., yolo = TRUE)
+  cv_select = TRUE, ..., yolo = TRUE)
 }
 \arguments{
 \item{X}{An input \code{matrix} containing observations and covariates
@@ -62,10 +62,11 @@ automatically select a CV-optimal value of this regularization parameter. If
 specified, the Lasso L1 regression model will be fit via \code{glmnet},
 returning regularized coefficient values for each value in the input array.}
 
-\item{fit_glmnet}{A \code{logical} specifying whether the array of values
+\item{cv_select}{A \code{logical} specifying whether the array of values
 specified should be passed to \code{cv.glmnet} in order to pick the optimal
-value (based on cross-validation) (when set to \code{FALSE}) or to simply
-fit along the sequence of values (or single value) using \code{glmnet}.}
+value (based on cross-validation) (when set to \code{TRUE}) or to simply
+fit along the sequence of values (or single value) using \code{glmnet} (when
+set to \code{FALSE}).}
 
 \item{...}{Other arguments passed to \code{cv.glmnet}. Please consult the
 documentation for \code{glmnet} for a full list of options.}

--- a/man/fit_hal.Rd
+++ b/man/fit_hal.Rd
@@ -7,8 +7,8 @@
 fit_hal(X, Y, degrees = NULL, fit_type = c("glmnet", "lassi"),
   n_folds = 10, use_min = TRUE, reduce_basis = NULL,
   family = c("gaussian", "binomial"), return_lasso = FALSE,
-  return_x_basis = FALSE, basis_list = NULL, lambda = NULL, ...,
-  yolo = TRUE)
+  return_x_basis = FALSE, basis_list = NULL, lambda = NULL,
+  fit_glmnet = FALSE, ..., yolo = TRUE)
 }
 \arguments{
 \item{X}{An input \code{matrix} containing observations and covariates
@@ -46,7 +46,7 @@ generalized linear model. Options are limited to "gaussian" for fitting a
 standard general linear model and "binomial" for logistic regression.}
 
 \item{return_lasso}{A \code{logical} indicating whether or not to return
-the HAL lasso fit.}
+the \code{glmnet} fit of the lasso model.}
 
 \item{return_x_basis}{A \code{logical} indicating whether or not to return
 the matrix of (possibly reduced) basis functions used in the HAL lasso fit.}
@@ -58,8 +58,14 @@ and d is the number of columns in X.}
 
 \item{lambda}{A user-specified array of values of the lambda tuning parameter
 of the Lasso L1 regression. If \code{NULL}, \code{cv.glmnet} will be used to
-automatically select a CV-optimal value of this parameter. If specified, the
-Lasso L1 regression model will be fit via \code{glmnet}.}
+automatically select a CV-optimal value of this regularization parameter. If
+specified, the Lasso L1 regression model will be fit via \code{glmnet},
+returning regularized coefficient values for each value in the input array.}
+
+\item{fit_glmnet}{A \code{logical} specifying whether the array of values
+specified should be passed to \code{cv.glmnet} in order to pick the optimal
+value (based on cross-validation) (when set to \code{FALSE}) or to simply
+fit along the sequence of values (or single value) using \code{glmnet}.}
 
 \item{...}{Other arguments passed to \code{cv.glmnet}. Please consult the
 documentation for \code{glmnet} for a full list of options.}

--- a/src/dedupe.cpp
+++ b/src/dedupe.cpp
@@ -45,6 +45,8 @@ IntegerVector index_first_copy(const MSpMat& X) {
 //' @param X Sparse matrix containing columns of indicator functions.
 //' @param copy_map the copy map
 //'
+//' @export
+//'
 // [[Rcpp::export]]
 SpMat apply_copy_map(const MSpMat X, const List& copy_map) {
   int n = X.rows();
@@ -71,5 +73,4 @@ SpMat apply_copy_map(const MSpMat X, const List& copy_map) {
   x_unique.makeCompressed();
   return(x_unique);
 }
-
 

--- a/src/dedupe.cpp
+++ b/src/dedupe.cpp
@@ -41,8 +41,10 @@ IntegerVector index_first_copy(const MSpMat& X) {
 //' Apply copy map
 //'
 //' OR duplicate training set columns together
+//'
 //' @param X Sparse matrix containing columns of indicator functions.
 //' @param copy_map the copy map
+//'
 // [[Rcpp::export]]
 SpMat apply_copy_map(const MSpMat X, const List& copy_map) {
   int n = X.rows();

--- a/src/make_hal_basis.cpp
+++ b/src/make_hal_basis.cpp
@@ -131,6 +131,8 @@ void evaluate_basis(const List& basis, const NumericMatrix& X, SpMat& x_basis,
 //' @param X Matrix of covariates containing observed data in the columns.
 //' @param blist List of basis functions with which to build HAL design matrix.
 //'
+//' @export
+//'
 // [[Rcpp::export]]
 SpMat make_design_matrix(const NumericMatrix& X, const List& blist) {
   //now generate an indicator vector for each

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -83,10 +83,10 @@ NumericVector calc_xscale(const MSpMat& X, const NumericVector& xcenter) {
  NumericVector pnz = get_pnz(X);
  NumericVector xscale = not_dumb_sqrt(pnz);
  double minx = std::sqrt(1.0 / n);
- 
+
  xscale = not_dumb_sqrt(xscale * xscale - (xcenter * xcenter));
  xscale[xscale == 0 ] = minx;
- 
+
  return(xscale);
 }
 
@@ -96,10 +96,10 @@ NumericVector get_xscale(const MSpMat& X, const NumericVector& xcenter) {
   NumericVector pnz = get_pnz(X);
   NumericVector xscale = not_dumb_sqrt(pnz);
   double minx = std::sqrt(1.0 / n);
-  
+
   xscale = not_dumb_sqrt(xscale * xscale - (xcenter * xcenter));
   xscale[xscale == 0 ] = minx;
-  
+
   return(xscale);
 }
 
@@ -117,6 +117,5 @@ double soft_max(double beta, double lambda){
   } else {
     beta = 0;
   }
-  
   return(beta);
 }

--- a/tests/testthat/test-cv_lasso.R
+++ b/tests/testthat/test-cv_lasso.R
@@ -142,11 +142,15 @@ betas_cvglmnet_lassi <- cbind(
 # TEST THAT ORIGAMI AND CV-GLMNET IMPLEMENTATIONS MATCH
 ################################################################################
 test_that("lambda-min difference between cv.glmnet, cv_lasso within 0.5%.", {
-  expect_lte(lambda_minmse_origami - lambda_minmse_cvglmnet,
-             lambda_minmse_cvglmnet * 0.005)
+  expect_lte(
+    lambda_minmse_origami - lambda_minmse_cvglmnet,
+    lambda_minmse_cvglmnet * 0.005
+  )
 })
 
 test_that("lambda-1se difference between cv.glmnet and cv_lasso within 1%.", {
-  expect_lte(lambda_minmse_origami - lambda_minmse_cvglmnet,
-             lambda_minmse_cvglmnet * 0.01)
+  expect_lte(
+    lambda_minmse_origami - lambda_minmse_cvglmnet,
+    lambda_minmse_cvglmnet * 0.01
+  )
 })

--- a/tests/testthat/test-cv_lasso.R
+++ b/tests/testthat/test-cv_lasso.R
@@ -142,9 +142,11 @@ betas_cvglmnet_lassi <- cbind(
 # TEST THAT ORIGAMI AND CV-GLMNET IMPLEMENTATIONS MATCH
 ################################################################################
 test_that("lambda-min difference between cv.glmnet, cv_lasso within 0.5%.", {
-  expect_lte(lambda_minmse_origami - lambda_minmse_cvglmnet, lambda_minmse_cvglmnet * 0.005)
+  expect_lte(lambda_minmse_origami - lambda_minmse_cvglmnet,
+             lambda_minmse_cvglmnet * 0.005)
 })
 
 test_that("lambda-1se difference between cv.glmnet and cv_lasso within 1%.", {
-  expect_lte(lambda_minmse_origami - lambda_minmse_cvglmnet, lambda_minmse_cvglmnet * 0.01)
+  expect_lte(lambda_minmse_origami - lambda_minmse_cvglmnet,
+             lambda_minmse_cvglmnet * 0.01)
 })

--- a/tests/testthat/test-single_lambda.R
+++ b/tests/testthat/test-single_lambda.R
@@ -17,7 +17,7 @@ hal_fit <- fit_hal(
   fit_type = "glmnet",
   family = "binomial",
   lambda = 2e-2,
-  fit_glmnet = TRUE,
+  cv_select = FALSE,
   return_lasso = TRUE
 )
 
@@ -30,4 +30,3 @@ test_that("a single glmnet object is output", {
 test_that("cv.glmnet object is not output", {
   expect(is.null(hal_fit$hal_lasso))
 })
-

--- a/tests/testthat/test-single_lambda.R
+++ b/tests/testthat/test-single_lambda.R
@@ -7,6 +7,7 @@ x <- rnorm(n)
 y <- as.numeric(expit(2 * x + rnorm(n)) > .5)
 wgt <- rep(1, n)
 
+# fit via call to glmnet::glmnet for a single value of lambda
 hal_fit <- fit_hal(
   X = x,
   Y = y,
@@ -16,8 +17,12 @@ hal_fit <- fit_hal(
   fit_type = "glmnet",
   family = "binomial",
   lambda = 2e-2,
+  fit_glmnet = TRUE,
   return_lasso = TRUE
 )
+
+# get predictions
+yhat <- predict(hal_fit, new_data = x)
 
 test_that("a single glmnet object is output", {
   expect("glmnet" %in% class(hal_fit$glmnet_lasso))
@@ -26,5 +31,3 @@ test_that("cv.glmnet object is not output", {
   expect(is.null(hal_fit$hal_lasso))
 })
 
-yhat <- predict(hal_fit, new_data = x)
-# plot(expit(yhat) ~ x, ylim = c(0, 1))

--- a/vignettes/intro_hal9001.Rmd
+++ b/vignettes/intro_hal9001.Rmd
@@ -13,22 +13,19 @@ vignette: >
 
 ## Introduction
 
-The _highly adaptive LASSO_ (HAL) is a flexible machine learning algorithm that
+The _highly adaptive Lasso_ (HAL) is a flexible machine learning algorithm that
 nonparametrically estimates a function based on available data by embedding a
 set of input observations and covariates in an extremely high-dimensional space
 (i.e., generating basis functions from the available data). For an input data
 matrix of $n$ observations and $d$ covariates, the number of basis functions
 generated is approximately $n \cdot 2^{d - 1}$. To select a set of basis
-functions from among the full set generated, the LASSO is employed. The
+functions from among the full set generated, the Lasso is employed. The
 `hal9001` R package provides an efficient implementation of this routine,
-relying on the `glmnet` R package for compatibility with the canonical LASSO
+relying on the `glmnet` R package for compatibility with the canonical Lasso
 implementation while still providing a (faster) custom C++ routine for using the
-LASSO with an input matrix composed of indicator functions. Consider consulting
-the following references for more detailed descriptions of HAL:
-
-1. [@benkeser2016hal],
-2. [@vdl2015generally],
-3. [@vdl2017finite].
+Lasso with an input matrix composed of indicator functions. Consider consulting
+@benkeser2016hal, @vdl2015generally, @vdl2017finite for detailed theoretical
+descriptions of the highly adaptive Lasso and its various optimality properties.
 
 ---
 
@@ -65,7 +62,7 @@ head(y)
 
 ---
 
-## Using the Highly Adaptive LASSO
+## Using the Highly Adaptive Lasso
 
 ```{r}
 library(hal9001)


### PR DESCRIPTION
This PR makes breaking changes to how some of the arguments in `fit_hal` are used to call `glmnet` in fitting Lasso models over a pre-specified range of tuning parameter values. These changes improve how `hal9001` handles such a case and are required for the density estimation functionality exposed in the `haldensify` R package.