### PR TITLE
JOSS paper

### DIFF
--- a/paper/paper.md
+++ b/paper/paper.md
@@ -1,5 +1,5 @@
 ---
-title: "`hal9001`: Scalable estimation with the highly adaptive lasso in `R`"
+title: "`hal9001`: Scalable highly adaptive lasso regression in `R`"
 tags:
   - machine learning
   - targeted learning
@@ -24,70 +24,54 @@ affiliations:
     index: 3
   - name: Center for Computational Biology, University of California, Berkeley
     index: 4
-date: 20 July 2020
+date: 22 June 2020
 bibliography: refs.bib
 ---
 
 # Summary
 
+The `hal9001` `R` package provides access to the _highly adaptive lasso_,
+a highly flexible nonparametric regression and machine learning algorithm with
+many desirable theoretical properties. `hal9001` provides the canonical
+implementation of this algorithm, pairing the core statistical learning
+methodology with an array of practical variable selection tools and sensible
+defaults in order to improve the scalability of the procedure. By building off
+of existing `R` packages for lasso regression and leveraging C++ in key internal
+functions, the `hal9001` `R` attempts to provides relatively optimized highly
+adaptive lasso functionality, suitable for use both in data analysis tasks and
+modern (computationally intensive) statistics research.
+
+# Background
+
 A central problem in statistical learning theory and machine learning is the
-development of robust prediction functions, both in terms of learning complex
-functional forms and in the efficient estimation of low-dimensional
-function(al)s of possibly complex data-generating processes.
+development of efficient and robust prediction functions, which often require
+the learning of complex functional forms or the construction of efficient
+estimators of low-dimensional functionals of complex data-generating processes.
+For example, one may be interested in a nonparametric regression function that
+is unconstrained enough to (smoothly) estimate functions within a relatively
+rich class, or to estimate causal parameters like the average treatment effect,
+which require the consistent estimation of a limited set of nuisance functions.
+Most often, strong assumptions are made about the functional forms of relevant
+parts of the data-generating process, either out of convenience or due to
+limited computational resources.
 
 
-Causal inference has traditionally focused on the effects of static
-interventions, under which the magnitude of the treatment is set to a fixed,
-prespecified value for each unit. The evaluation of such interventions faces
-a host of issues, among them non-identification, violations of the assumption of
-positivity, and inefficiency. Stochastic interventions provide a promising
-solution to these fundamental issues by allowing for the target parameter to be
-defined as the mean counterfactual outcome under a hypothetically shifted
-version of the observed exposure distribution [@diaz2012population].
-Modified treatment policies, a particular class of such interventions, may be
-interpreted as shifting the natural exposure level at the level of a given
-observational unit [@haneuse2013estimation;@diaz2018stochastic].
-
-Despite the promise of such advances in causal inference, real data analyses are
-often further complicated by economic constraints, such as when the primary
-variable of interest is far more expensive to collect than auxiliary covariates.
-Two-phase sampling schemes are often used to bypass such limitations --
-unfortunately, their use produces side effects that require further adjustment
-when formal statistical inference is the principal goal of a study. Among the
-rich literature on two-phase designs, @rose2011targeted2sd stand out for
-providing a study of nonparametric efficiency theory under such designs. Their
-work can be used to construct efficient estimators of causal effects under
-general two-phase sampling designs.
-
-Building on these prior works, @hejazi2020efficient outlined a novel approach
-for use in such settings: augmented targeted minimum loss (TML) and one-step
-estimators for the causal effects of stochastic interventions, with guarantees
-of consistency, efficiency, and multiple robustness even in the presence of
-two-phase sampling. These authors further outlined a technique that summarizes
-the effect of shifting an exposure variable on the outcome of interest via
-a nonparametric working marginal structural model, analogous to a dose-response
-analysis. The `txshift` software package, for the `R` language and environment
-for statistical computing [@R], implements this methodology.
-
-
-`hal9001` is a scalable implementation of the highly adaptive lasso, built on
+is a scalable implementation of the highly adaptive lasso, built on
 top of the extremely popular `glmnet` `R` package [@friedman2009glmnet]. The
 `hal9001` `R` package includes tools
 
-for deploying these efficient estimators under two-phase
-sampling designs, with two types of corrections: (1) a reweighting procedure
-that introduces inverse probability of censoring weights directly into an
-appropriate loss function, as discussed in @rose2011targeted2sd; as
-well as (2) a correction based on the efficient influence function, studied more
-thoroughly by @hejazi2020efficient. `txshift`
-integrates with the [`sl3` package](https://github.com/tlverse/sl3)
-[@coyle2020sl3] to allow for ensemble machine learning to be leveraged in the
-estimation of nuisance parameters. What's more, the `txshift` package draws on
-both the `hal9001` and `haldensify` `R` packages [@coyle2019hal9001;
-@hejazi2020haldensify] to allow each of the estimators to be constructed in
-a manner consistent with the theoretical results of @hejazi2020efficient. The
-`txshift` package has been made publicly available via GitHub and will be
-submitted to the Comprehensive `R` Archive Network in the near future.
+
+# `hal9001`'s Scope
+
+[TO FILL IN]
+
+# `hal9001`'s Functionality
+
+[TO FILL IN]
+
+# Future Work
+
+Spline HAL
 
 # Acknowledgments
 

--- a/paper/paper.md
+++ b/paper/paper.md
@@ -24,7 +24,7 @@ affiliations:
     index: 3
   - name: Center for Computational Biology, University of California, Berkeley
     index: 4
-date: 22 June 2020
+date: 24 June 2020
 bibliography: refs.bib
 ---
 
@@ -37,7 +37,7 @@ pairs an implementation of this estimator with an array of practical variable
 selection tools and sensible defaults in order to improve the scalability of the
 algorithm. By building on existing `R` packages for lasso regression and
 leveraging compiled code in key internal functions, the `hal9001` `R` package
-provides a family of highly adaptive lasso estimators suitable for use both for
+provides a family of highly adaptive lasso estimators suitable for use in both
 modern data analysis tasks and computationally intensive statistics and machine
 learning research.
 
@@ -46,49 +46,39 @@ learning research.
 The highly adaptive lasso (HAL) is a nonparametric regression function capable
 of estimating complex (e.g., possibly infinite-dimensional) functional
 parameters at a near-parametric $n^{-1/3}$ rate under only relatively mild
-conditions [@vdl2017generally; @vdl2017uniform; @bibaut2019fast]. The `hal9001`
-package implements a zeroth-order HAL estimator, which constructs and selects
-(by lasso penalization) a linear combination of indicator basis functions to
-minimize the expected value of a loss function under the constraint that the
-$L_1$-norm of the vector of coefficients is bounded by a finite constant.
+conditions [@vdl2017generally; @vdl2017uniform; @bibaut2019fast]. HAL requires
+that the space of the functional parameter be a subset of the set of càdlàg
+(right-hand continuous with left-hand limits) functions with sectional
+sectional variation norm bounded by a constant. In contrast to the wealth of
+data adaptive regression techniques that make strong local smoothness
+assumptions on the true form of the target functional, HAL regression's
+assumption of a finite sectional variation norm constitutes only a _global_
+smoothness assumption, making it a powerful and versatile approach. The
+`hal9001` package implements a zeroth-order HAL estimator, which constructs and
+selects (by lasso penalization) a linear combination of indicator basis
+functions to minimize the loss-specific empirical risk under the constraint that
+the $L_1$-norm of the vector of coefficients be bounded by a finite constant.
 Importantly, the estimator is formulated such that this finite constant is the
-sectional variation norm of the target function's HAL representation.
+sectional variation norm of the target functional.
 
-To formalize, consider the space of $d$-variate real-valued càdlàg functions
-(right-hand continuous with left-hand limits) on a cube $[0,\tau] \in
-\mathbb{R}^d$, letting $\mathbb{D}[0,\tau]$ denote this Banach space. For an
-arbitrary functional $f \in \mathbb{D}[0,\tau]$, let the supremum norm be
-$\lVert f \rVert_{\infty} := \sup_{x \in [0, \tau]} \lvert f(x) \rvert$;
-morever, for any subset $s \subset \{0, \ldots, d\}$, partition the cube $[0,
-\tau]$ into $\{0\} \{\cup_s (0_s, \tau_s]\}$. The sectional variation norm of
-$f$ is defined
-\begin{equation*}
-  \lVert f \rVert^{\star}_\nu = \lvert f(0) \rvert + \sum_{s
-  \subset\{1, \ldots, d\}} \int_{0_s}^{\tau_s} \lvert df_s(u_s) \rvert,
-\end{equation*}
-with the sum being over all subsets of $\{0, \ldots, d\}$. Define $u_s = (u_j
-: j \in s)$ and $u_{-s}$ as the complement of $u_s$, for a given subset $s
-\subset \{0, \ldots, d\}$. Then, let $f_s(u_s) = f(u_s, 0_{-s})$, which yields
-$f_s: [0_s, \tau_s] \rightarrow \mathbb{R}$. $f_s(u_s)$ is simply a section of
-$f$ that sets the components in the complement of the subset $s$ to zero, i.e,
-allowing $f_s$ to vary only along components in $u_s$. Interestingly, this
-definition of variation norm corresponds closely with the notion of Hardy-Krause
-variation [@qiu2020universal; @owen2005multidimensional].
-
-For the purpose of estimation, the integral over the domain $[0_s, \tau_s]$ may
-be approximated by applying a discrete measure that places mass on observations
-$X_{s,i}$, for which coefficients $\beta_{s,i}$ are generated. Define the
-indicator $\phi_{s,i}(c_s)= \mathbb{I}(x_{s,i} \leq c_s)$, where $x_{s,i}$ are
-support points of the functional. Then, we may express the approximation as
-$\lVert \hat{f} \rVert^{\star}_\nu \approx \lvert \beta_0 \rvert + \sum_{s
-\subset\{1,\ldots,d\}} \sum_{i=1}^{n} \lvert \beta_{s,i} \rvert$, which
-approximates the sectional variation norm of the target functional. A loss-based
-HAL estimator is based on a choice of the penalization parameter $\lambda$ that
-minimizes the empirical risk under an appropriately chosen loss function. A data
-adaptively selected choice of $\lambda$, typically denoted $\lambda_n$, may be
-made by a cross-validation selector [@vdl2003unified; @vdv2006oracle], though
-alternative selection criteria may be more appropriate when the estimand
-functional is itself a nuisance component of the target parameter of interest
+Intuitively, construction of a HAL estimator proceeds in two steps. First,
+a design matrix composed of basis functions is generated based on the available
+set of covariates. The zeroth-order HAL makes use of indicator basis functions,
+resulting in a large, sparse matrix with binary entries; higher-order HAL
+estimators, which replace the use of indicator basis functions with splines,
+have been formulated but remain unimplemented. This representation of the target
+functional $f$ in terms of indicator basis functions partitions the support of
+$f$ into knot points, with indicator basis functions placed over subsets of the
+sections of $f$. Generally, very many basis functions are created, with an
+appropriate set of indicator bases then selected through lasso penalization.
+Thus, the second step of fitting a HAL model is performing $L_1$-penalized
+regression on the large, sparse design matrix of indicator bases. The selected
+HAL regression model approximates the sectional variation norm of the target
+functional as the absolute sum of the estimated coefficients of indicator basis
+functions. The $L_1$ penalization parameter $\lambda$ can be data adaptively
+selected based on a cross-validation selector [@vdl2003unified; @vdv2006oracle];
+however, alternative selection criteria may be more appropriate when the
+estimand functional is itself a nuisance component of the target parameter
 [e.g., @vdl2019efficient; @ertefaie2020nonparametric].
 
 # `hal9001`'s core functionality

--- a/paper/paper.md
+++ b/paper/paper.md
@@ -76,9 +76,9 @@ regression on the large, sparse design matrix of indicator bases. The selected
 HAL regression model approximates the sectional variation norm of the target
 functional as the absolute sum of the estimated coefficients of indicator basis
 functions. The $L_1$ penalization parameter $\lambda$ can be data adaptively
-selected based on a cross-validation selector [@vdl2003unified; @vdv2006oracle];
+chosen via a cross-validation selector [@vdl2003unified; @vdv2006oracle];
 however, alternative selection criteria may be more appropriate when the
-estimand functional is itself a nuisance component of the target parameter
+estimand functional is not the target parameter but instead a nuisance function
 [e.g., @vdl2019efficient; @ertefaie2020nonparametric].
 
 # `hal9001`'s core functionality

--- a/paper/paper.md
+++ b/paper/paper.md
@@ -105,14 +105,15 @@ Over several years of development and use, it was found that the performance of
 HAL regression can suffer in high-dimensional settings. To alleviate
 computational aspects of this issue, several screening and filtering approaches
 were investigated and implemented. These include screening of variables prior to
-creating the design matrix and filtering of indicator basis functions (arguments
-`screen_basis` and `reduce_basis`), as well as either filtering of penalization
-parameters (argument `screen_lambda`) or early stopping when fitting the
-sequence of HAL models in $\lambda$. Future software development efforts will
-continue to improve upon the computational aspects and performance of the HAL
-regression options supported by `hal9001`. Currently, stable releases of the
-`hal9001` package are made available on the Comprehensive `R` Archive Network at
-https://CRAN.R-project.org/package=hal9001.
+creating the design matrix and filtering of indicator basis functions (argument
+`reduce_basis`) as well as early stopping when fitting the sequence of HAL
+models in $\lambda$. Future software development efforts will continue to
+improve upon the computational aspects and performance of the HAL regression
+options supported by `hal9001`. Currently, stable releases of the `hal9001`
+package are made available on the Comprehensive `R` Archive Network at
+https://CRAN.R-project.org/package=hal9001, while both stable (branch `master`)
+and development (branch `devel`) versions of the package are hosted at
+https://github.com/tlverse/hal9001.
 
 # References
 

--- a/paper/paper.md
+++ b/paper/paper.md
@@ -1,0 +1,99 @@
+---
+title: "`hal9001`: Scalable estimation with the highly adaptive lasso in `R`"
+tags:
+  - machine learning
+  - targeted learning
+  - causal inference
+  - R
+authors:
+  - name: Nima S. Hejazi
+    orcid: 0000-0002-7127-2789
+    affiliation: 1, 4
+  - name: Jeremy R. Coyle
+    orcid: 0000-0002-9874-6649
+    affiliation: 2
+  - name: Mark J. van der Laan
+    orcid: 0000-0003-1432-5511
+    affiliation: 2, 3, 4
+affiliations:
+  - name: Graduate Group in Biostatistics, University of California, Berkeley
+    index: 1
+  - name: Division of Epidemiology & Biostatistics, School of Public Health, University of California, Berkeley
+    index: 2
+  - name: Department of Statistics, University of California, Berkeley
+    index: 3
+  - name: Center for Computational Biology, University of California, Berkeley
+    index: 4
+date: 20 July 2020
+bibliography: refs.bib
+---
+
+# Summary
+
+A central problem in statistical learning theory and machine learning is the
+development of robust prediction functions, both in terms of learning complex
+functional forms and in the efficient estimation of low-dimensional
+function(al)s of possibly complex data-generating processes.
+
+
+Causal inference has traditionally focused on the effects of static
+interventions, under which the magnitude of the treatment is set to a fixed,
+prespecified value for each unit. The evaluation of such interventions faces
+a host of issues, among them non-identification, violations of the assumption of
+positivity, and inefficiency. Stochastic interventions provide a promising
+solution to these fundamental issues by allowing for the target parameter to be
+defined as the mean counterfactual outcome under a hypothetically shifted
+version of the observed exposure distribution [@diaz2012population].
+Modified treatment policies, a particular class of such interventions, may be
+interpreted as shifting the natural exposure level at the level of a given
+observational unit [@haneuse2013estimation;@diaz2018stochastic].
+
+Despite the promise of such advances in causal inference, real data analyses are
+often further complicated by economic constraints, such as when the primary
+variable of interest is far more expensive to collect than auxiliary covariates.
+Two-phase sampling schemes are often used to bypass such limitations --
+unfortunately, their use produces side effects that require further adjustment
+when formal statistical inference is the principal goal of a study. Among the
+rich literature on two-phase designs, @rose2011targeted2sd stand out for
+providing a study of nonparametric efficiency theory under such designs. Their
+work can be used to construct efficient estimators of causal effects under
+general two-phase sampling designs.
+
+Building on these prior works, @hejazi2020efficient outlined a novel approach
+for use in such settings: augmented targeted minimum loss (TML) and one-step
+estimators for the causal effects of stochastic interventions, with guarantees
+of consistency, efficiency, and multiple robustness even in the presence of
+two-phase sampling. These authors further outlined a technique that summarizes
+the effect of shifting an exposure variable on the outcome of interest via
+a nonparametric working marginal structural model, analogous to a dose-response
+analysis. The `txshift` software package, for the `R` language and environment
+for statistical computing [@R], implements this methodology.
+
+
+`hal9001` is a scalable implementation of the highly adaptive lasso, built on
+top of the extremely popular `glmnet` `R` package [@friedman2009glmnet]. The
+`hal9001` `R` package includes tools
+
+for deploying these efficient estimators under two-phase
+sampling designs, with two types of corrections: (1) a reweighting procedure
+that introduces inverse probability of censoring weights directly into an
+appropriate loss function, as discussed in @rose2011targeted2sd; as
+well as (2) a correction based on the efficient influence function, studied more
+thoroughly by @hejazi2020efficient. `txshift`
+integrates with the [`sl3` package](https://github.com/tlverse/sl3)
+[@coyle2020sl3] to allow for ensemble machine learning to be leveraged in the
+estimation of nuisance parameters. What's more, the `txshift` package draws on
+both the `hal9001` and `haldensify` `R` packages [@coyle2019hal9001;
+@hejazi2020haldensify] to allow each of the estimators to be constructed in
+a manner consistent with the theoretical results of @hejazi2020efficient. The
+`txshift` package has been made publicly available via GitHub and will be
+submitted to the Comprehensive `R` Archive Network in the near future.
+
+# Acknowledgments
+
+Nima Hejazi's contributions to this work were supported in part by a grant from
+the National Institutes of Health: [T32
+LM012417-02](https://projectreporter.nih.gov/project_info_description.cfm?aid=9248418&icde=37849831&ddparam=&ddvalue=&ddsub=&cr=1&csb=default&cs=ASC&pball=).
+
+# References
+

--- a/paper/paper.md
+++ b/paper/paper.md
@@ -30,54 +30,99 @@ bibliography: refs.bib
 
 # Summary
 
-The `hal9001` `R` package provides access to the _highly adaptive lasso_,
-a highly flexible nonparametric regression and machine learning algorithm with
-many desirable theoretical properties. `hal9001` provides the canonical
-implementation of this algorithm, pairing the core statistical learning
-methodology with an array of practical variable selection tools and sensible
-defaults in order to improve the scalability of the procedure. By building off
-of existing `R` packages for lasso regression and leveraging C++ in key internal
-functions, the `hal9001` `R` attempts to provides relatively optimized highly
-adaptive lasso functionality, suitable for use both in data analysis tasks and
-modern (computationally intensive) statistics research.
+The `hal9001` `R` package provides an efficient implementation of the _highly
+adaptive lasso_ (HAL), a flexible nonparametric regression and machine learning
+algorithm endowed with several theoretically convenient properties. `hal9001`
+pairs an implementation of this estimator with an array of practical variable
+selection tools and sensible defaults in order to improve the scalability of the
+algorithm. By building on existing `R` packages for lasso regression and
+leveraging compiled code in key internal functions, the `hal9001` `R` package
+provides a family of highly adaptive lasso estimators suitable for use both for
+modern data analysis tasks and computationally intensive statistics and machine
+learning research.
 
 # Background
 
-A central problem in statistical learning theory and machine learning is the
-development of efficient and robust prediction functions, which often require
-the learning of complex functional forms or the construction of efficient
-estimators of low-dimensional functionals of complex data-generating processes.
-For example, one may be interested in a nonparametric regression function that
-is unconstrained enough to (smoothly) estimate functions within a relatively
-rich class, or to estimate causal parameters like the average treatment effect,
-which require the consistent estimation of a limited set of nuisance functions.
-Most often, strong assumptions are made about the functional forms of relevant
-parts of the data-generating process, either out of convenience or due to
-limited computational resources.
+The highly adaptive lasso (HAL) is a nonparametric regression function capable
+of estimating complex (e.g., possibly infinite-dimensional) functional
+parameters at a near-parametric $n^{-1/3}$ rate under only relatively mild
+conditions [@vdl2017generally; @vdl2017uniform; @bibaut2019fast]. The `hal9001`
+package implements a zeroth-order HAL estimator, which constructs and selects
+(by lasso penalization) a linear combination of indicator basis functions to
+minimize the expected value of a loss function under the constraint that the
+$L_1$-norm of the vector of coefficients is bounded by a finite constant.
+Importantly, the estimator is formulated such that this finite constant is the
+sectional variation norm of the target function's HAL representation.
 
+To formalize, consider the space of $d$-variate real-valued càdlàg functions
+(right-hand continuous with left-hand limits) on a cube $[0,\tau] \in
+\mathbb{R}^d$, letting $\mathbb{D}[0,\tau]$ denote this Banach space. For an
+arbitrary functional $f \in \mathbb{D}[0,\tau]$, let the supremum norm be
+$\lVert f \rVert_{\infty} := \sup_{x \in [0, \tau]} \lvert f(x) \rvert$;
+morever, for any subset $s \subset \{0, \ldots, d\}$, partition the cube $[0,
+\tau]$ into $\{0\} \{\cup_s (0_s, \tau_s]\}$. The sectional variation norm of
+$f$ is defined
+\begin{equation*}
+  \lVert f \rVert^{\star}_\nu = \lvert f(0) \rvert + \sum_{s
+  \subset\{1, \ldots, d\}} \int_{0_s}^{\tau_s} \lvert df_s(u_s) \rvert,
+\end{equation*}
+with the sum being over all subsets of $\{0, \ldots, d\}$. Define $u_s = (u_j
+: j \in s)$ and $u_{-s}$ as the complement of $u_s$, for a given subset $s
+\subset \{0, \ldots, d\}$. Then, let $f_s(u_s) = f(u_s, 0_{-s})$, which yields
+$f_s: [0_s, \tau_s] \rightarrow \mathbb{R}$. $f_s(u_s)$ is simply a section of
+$f$ that sets the components in the complement of the subset $s$ to zero, i.e,
+allowing $f_s$ to vary only along components in $u_s$. Interestingly, this
+definition of variation norm corresponds closely with the notion of Hardy-Krause
+variation [@qiu2020universal; @owen2005multidimensional].
 
-is a scalable implementation of the highly adaptive lasso, built on
-top of the extremely popular `glmnet` `R` package [@friedman2009glmnet]. The
-`hal9001` `R` package includes tools
+For the purpose of estimation, the integral over the domain $[0_s, \tau_s]$ may
+be approximated by applying a discrete measure that places mass on observations
+$X_{s,i}$, for which coefficients $\beta_{s,i}$ are generated. Define the
+indicator $\phi_{s,i}(c_s)= \mathbb{I}(x_{s,i} \leq c_s)$, where $x_{s,i}$ are
+support points of the functional. Then, we may express the approximation as
+$\lVert \hat{f} \rVert^{\star}_\nu \approx \lvert \beta_0 \rvert + \sum_{s
+\subset\{1,\ldots,d\}} \sum_{i=1}^{n} \lvert \beta_{s,i} \rvert$, which
+approximates the sectional variation norm of the target functional. A loss-based
+HAL estimator is based on a choice of the penalization parameter $\lambda$ that
+minimizes the empirical risk under an appropriately chosen loss function. A data
+adaptively selected choice of $\lambda$, typically denoted $\lambda_n$, may be
+made by a cross-validation selector [@vdl2003unified; @vdv2006oracle], though
+alternative selection criteria may be more appropriate when the estimand
+functional is itself a nuisance component of the target parameter of interest
+[e.g., @vdl2019efficient; @ertefaie2020nonparametric].
 
+# `hal9001`'s core functionality
 
-# `hal9001`'s Scope
+The `hal9001` package, for the `R` language and environment for statistical
+computing [@R], aims to provide a scalable implementation of the HAL regression
+function. To provide a single, unified interface, the principal user-facing
+function is `fit_hal()`, which, at minimum, requires a matrix of predictors `X`
+and an outcome `Y`. By default, invocation of `fit_hal()` will build a HAL model
+using indicator basis functions for up to a limited number of interactions of
+the variables in `X`, fitting the penalized regression model via the lasso
+procedure available in the extremely popular `glmnet` `R` package
+[@friedman2009glmnet]. As creation of the design matrix of indicator basis
+functions can be computationally expensive, several helper functions (e.g.,
+`make_design_matrix()`, `make_basis_list()`, `make_copy_map()`) have been
+written in C++ and integrated into the package via the `Rcpp` framework
+[@eddelbuettel2011rcpp; @eddelbuettel2013seamless]. `hal9001` additionally
+supports the fitting of standard (Gaussian), logistic, and Cox proportional
+hazards models (argument `family`), including variations that accommodate
+offsets (argument `offset`) and partially penalized linear models (argument
+`X_unpenalized`).
 
-[TO FILL IN]
-
-# `hal9001`'s Functionality
-
-[TO FILL IN]
-
-# Future Work
-
-Spline HAL
-
-# Acknowledgments
-
-Nima Hejazi's contributions to this work were supported in part by a grant from
-the National Institutes of Health: [T32
-LM012417-02](https://projectreporter.nih.gov/project_info_description.cfm?aid=9248418&icde=37849831&ddparam=&ddvalue=&ddsub=&cr=1&csb=default&cs=ASC&pball=).
+Over several years of development and use, it was found that the performance of
+HAL regression can suffer in high-dimensional settings. To alleviate
+computational aspects of this issue, several screening and filtering approaches
+were investigated and implemented. These include screening of variables prior to
+creating the design matrix and filtering of indicator basis functions (arguments
+`screen_basis` and `reduce_basis`), as well as either filtering of penalization
+parameters (argument `screen_lambda`) or early stopping when fitting the
+sequence of HAL models in $\lambda$. Future software development efforts will
+continue to improve upon the computational aspects and performance of the HAL
+regression options supported by `hal9001`. Currently, stable releases of the
+`hal9001` package are made available on the Comprehensive `R` Archive Network at
+https://CRAN.R-project.org/package=hal9001.
 
 # References
 

--- a/paper/refs.bib
+++ b/paper/refs.bib
@@ -1,0 +1,107 @@
+@inproceedings{benkeser2016hal,
+  doi = {10.1109/dsaa.2016.93},
+  url = {https://doi.org/10.1109/dsaa.2016.93},
+  year  = {2016},
+  publisher = {{IEEE}},
+  author = {Benkeser, David and {van der Laan}, Mark J},
+  title = {The Highly Adaptive Lasso Estimator},
+  booktitle = {2016 {IEEE} International Conference on Data Science and Advanced
+    Analytics ({DSAA})}
+}
+
+@article{vdl2015generally,
+  author = {{van der Laan}, Mark J},
+  publisher = {bepress},
+  title = {A generally efficient targeted minimum loss based estimator},
+  year = {2015}
+}
+
+@article{vdl2017generally,
+  doi = {10.1515/ijb-2015-0097},
+  url = {https://doi.org/10.1515/ijb-2015-0097},
+  title = {A Generally Efficient Targeted Minimum Loss Based Estimator based on
+    the {Highly Adaptive Lasso}},
+  author = {{van der Laan}, Mark J},
+  journal = {The International Journal of Biostatistics},
+  year = {2017},
+  publisher = {De Gruyter}
+}
+
+@article{vdl2017finite,
+  title = {Finite sample inference for {Targeted Learning}},
+  author = {{van der Laan}, Mark J},
+  journal = {ArXiv e-prints},
+  archivePrefix = "arXiv",
+  eprint = {1708.09502},
+  primaryClass = "math.ST",
+  keywords = {Mathematics - Statistics Theory},
+  year = {2017}
+}
+
+@article{bibaut2019fast,
+  author = {Bibaut, Aur{\'e}lien F and {van der Laan}, Mark J},
+  journal = {arXiv preprint arXiv:1907.09244},
+  title = {Fast rates for empirical risk minimization over
+    c\`{a}dl\`{a}g functions with bounded sectional variation norm},
+  year = {2019}
+}
+
+@article{bang2005doubly,
+  Author = {Bang, Heejung and Robins, James M},
+  Journal = {Biometrics},
+  Number = {4},
+  Pages = {962--973},
+  Publisher = {Wiley Online Library},
+  Title = {Doubly robust estimation in missing data and causal inference
+    models},
+  Volume = {61},
+  Year = {2005}
+}
+
+@article{vdl2019efficient,
+  Author = {{van der Laan}, Mark J and Benkeser, David and Cai, Weixin},
+  Journal = {arXiv preprint arXiv:1908.05607},
+  Title = {Efficient estimation of pathwise differentiable target parameters
+    with the undersmoothed highly adaptive lasso},
+  Year = {2019}
+}
+
+@article{vdl2017uniform,
+  Author = {{van der Laan}, Mark J and Bibaut, Aur{\'e}lien F},
+  Journal = {arXiv preprint arXiv:1709.06256},
+  Title = {Uniform Consistency of the Highly Adaptive Lasso Estimator of
+    Infinite-Dimensional Parameters},
+  Year = {2017}
+}
+
+@article{ertefaie2020nonparametric,
+  doi = {},
+  url = {http://arxiv.org/abs/2005.11303},
+  year = {2020},
+  publisher = {},
+  journal = {},
+  volume = {},
+  number = {},
+  pages = {},
+  author = {Ertefaie, Ashkan and Hejazi, Nima S and {van der Laan}, Mark J},
+  title = {Nonparametric inverse probability weighted estimators based on the
+    highly adaptive lasso}
+}
+
+@manual{R,
+  address = {Vienna, Austria},
+  author = {{R Core Team}},
+  organization = {R Foundation for Statistical Computing},
+  title = {\text{R}: A Language and Environment for Statistical Computing},
+  url = {https://www.R-project.org/},
+  year = {2020}
+}
+
+@article{friedman2009glmnet,
+  title={glmnet: Lasso and elastic-net regularized generalized linear models},
+  author={Friedman, Jerome and Hastie, Trevor and Tibshirani, Rob},
+  journal={R package version},
+  volume={1},
+  number={4},
+  year={2009}
+}

--- a/paper/refs.bib
+++ b/paper/refs.bib
@@ -105,3 +105,83 @@
   number={4},
   year={2009}
 }
+
+@incollection{owen2005multidimensional,
+  title={Multidimensional variation for quasi-Monte Carlo},
+  author={Owen, Art B},
+  booktitle={Contemporary Multivariate Analysis And Design Of Experiments: In
+    Celebration of Professor Kai-Tai Fang's 65th Birthday},
+  pages={49--74},
+  year={2005},
+  publisher={World Scientific}
+}
+
+@article{qiu2020universal,
+  title={Universal sieve-based strategies for efficient estimation using
+    machine learning tools},
+  author={Qiu, Hongxiang and Luedtke, Alex and Carone, Marco},
+  journal={arXiv preprint arXiv:2003.01856},
+  year={2020}
+}
+
+@techreport{vdl2003unified,
+author = {{van der Laan}, Mark J and Dudoit, Sandrine},
+institution = {Division of Biostatistics, University of California, Berkeley},
+keywords = {Superlearner},
+number = {130},
+title = {{Unified cross-validation methodology for selection among estimators
+  and a general cross-validated adaptive epsilon-net estimator: finite sample
+  oracle inequalities and examples}},
+year = {2003}
+}
+
+@article{vdv2006oracle,
+author = {{van der Vaart}, Aad W and Dudoit, Sandrine and {van der Laan}, Mark
+  J},
+title = {{Oracle inequalities for multi-fold cross validation}},
+journal = {Statistics \& Decisions},
+year = {2006},
+volume = {24},
+number = {3},
+pages = {351--371}
+}
+
+@article{ertefaie2020nonparametric,
+  doi = {},
+  url = {http://arxiv.org/abs/2005.11303},
+  year = {2020},
+  publisher = {},
+  journal = {},
+  volume = {},
+  number = {},
+  pages = {},
+  author = {Ertefaie, Ashkan and Hejazi, Nima S and {van der Laan}, Mark J},
+  title = {Nonparametric inverse probability weighted estimators based on the
+    highly adaptive lasso}
+}
+
+@article{vdl2019efficient,
+  title={Efficient estimation of pathwise differentiable target parameters with
+    the undersmoothed highly adaptive lasso},
+  author={{van der Laan}, Mark J and Benkeser, David and Cai, Weixin},
+  journal={arXiv preprint arXiv:1908.05607},
+  year={2019}
+}
+
+@article{eddelbuettel2011rcpp,
+  title={Rcpp: Seamless R and C++ integration},
+  author={Eddelbuettel, Dirk and Fran{\c{c}}ois, Romain and Allaire, J and
+    Ushey, Kevin and Kou, Qiang and Russel, N and Chambers, John and Bates, D},
+  journal={Journal of Statistical Software},
+  volume={40},
+  number={8},
+  pages={1--18},
+  year={2011}
+}
+
+@book{eddelbuettel2013seamless,
+  title={Seamless R and C++ integration with Rcpp},
+  author={Eddelbuettel, Dirk},
+  year={2013},
+  publisher={Springer}
+}


### PR DESCRIPTION
A short software paper has been drafted and added to the new paper subdirectory for submission to JOSS: https://joss.theoj.org/.