### PR TITLE
Basis filter fix

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: hal9001
 Title: The Scalable Highly Adaptive Lasso
-Version: 0.2.6
+Version: 0.2.7
 Authors@R: c(
   person("Jeremy", "Coyle", email = "jeremyrcoyle@gmail.com",
          role = c("aut", "cre"),

--- a/R/hal.R
+++ b/R/hal.R
@@ -327,4 +327,3 @@ fit_hal <- function(X,
   class(fit) <- "hal9001"
   return(fit)
 }
-

--- a/R/predict.R
+++ b/R/predict.R
@@ -44,6 +44,10 @@ predict.hal9001 <- function(object,
 
   # generate design matrix
   pred_x_basis <- make_design_matrix(new_data, object$basis_list)
+  group <- object$copy_map[[1]]
+
+  # reduce matrix of basis functions
+  pred_x_basis <- apply_copy_map(pred_x_basis, object$copy_map)
 
   # add unpenalized covariates
   new_unpenalized_covariates <- ifelse(

--- a/R/predict.R
+++ b/R/predict.R
@@ -24,7 +24,7 @@
 #'
 #' @note This prediction method does not function similarly to the equivalent
 #'  method from \pkg{glmnet}. In particular, this procedure will NOT return a
-#'  subset of lambdas originally specified in callingo \code{\link{fit_hal}}
+#'  subset of lambdas originally specified in calling \code{\link{fit_hal}}
 #'  nor result in re-fitting. Instead, it will return predictions for all of
 #'  the lambdas specified in the call to \code{\link{fit_hal}} that constructs
 #'  \code{object}, when \code{cv_select = FALSE}. When \code{cv_select = TRUE},
@@ -44,19 +44,6 @@ predict.hal9001 <- function(object,
 
   # generate design matrix
   pred_x_basis <- make_design_matrix(new_data, object$basis_list)
-  group <- object$copy_map[[1]]
-
-  # reduce matrix of basis functions
-  pred_x_basis <- apply_copy_map(pred_x_basis, object$copy_map)
-
-  # NOTE: keep only basis functions with some (or higher) proportion of 1's
-  if (!is.null(object$reduce_basis) && is.numeric(object$reduce_basis)) {
-    reduced_basis_map <- make_reduced_basis_map(
-      pred_x_basis,
-      object$reduce_basis
-    )
-    pred_x_basis <- pred_x_basis[, reduced_basis_map]
-  }
 
   # add unpenalized covariates
   new_unpenalized_covariates <- ifelse(
@@ -72,7 +59,7 @@ predict.hal9001 <- function(object,
   # column rank of X_unpenalized should be consistent between the prediction
   # and training phases
   assertthat::assert_that(object$unpenalized_covariates ==
-    new_unpenalized_covariates)
+                            new_unpenalized_covariates)
   if (new_unpenalized_covariates > 0) {
     pred_x_basis <- cbind(pred_x_basis, new_X_unpenalized)
   }

--- a/R/predict.R
+++ b/R/predict.R
@@ -63,7 +63,7 @@ predict.hal9001 <- function(object,
   # column rank of X_unpenalized should be consistent between the prediction
   # and training phases
   assertthat::assert_that(object$unpenalized_covariates ==
-                            new_unpenalized_covariates)
+    new_unpenalized_covariates)
   if (new_unpenalized_covariates > 0) {
     pred_x_basis <- cbind(pred_x_basis, new_X_unpenalized)
   }

--- a/README.Rmd
+++ b/README.Rmd
@@ -17,7 +17,7 @@ knitr::opts_chunk$set(
 # R/`hal9001`
 
 [![Travis-CI Build Status](https://travis-ci.org/tlverse/hal9001.svg?branch=master)](https://travis-ci.org/tlverse/hal9001)
-[![AppVeyor Build Status](https://ci.appveyor.com/api/projects/status/github/jeremyrcoyle/hal9001?branch=master&svg=true)](https://ci.appveyor.com/project/jeremyrcoyle/hal9001)
+[![AppVeyor Build Status](https://ci.appveyor.com/api/projects/status/github/tlverse/hal9001?branch=master&svg=true)](https://ci.appveyor.com/project/tlverse/hal9001)
 [![Coverage Status](https://img.shields.io/codecov/c/github/tlverse/hal9001/master.svg)](https://codecov.io/github/tlverse/hal9001?branch=master)
 [![CRAN](http://www.r-pkg.org/badges/version/hal9001)](http://www.r-pkg.org/pkg/hal9001)
 [![CRAN downloads](https://cranlogs.r-pkg.org/badges/hal9001)](https://CRAN.R-project.org/package=hal9001)

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Travis-CI Build
 Status](https://travis-ci.org/tlverse/hal9001.svg?branch=master)](https://travis-ci.org/tlverse/hal9001)
 [![AppVeyor Build
-Status](https://ci.appveyor.com/api/projects/status/github/jeremyrcoyle/hal9001?branch=master&svg=true)](https://ci.appveyor.com/project/jeremyrcoyle/hal9001)
+Status](https://ci.appveyor.com/api/projects/status/github/tlverse/hal9001?branch=master&svg=true)](https://ci.appveyor.com/project/tlverse/hal9001)
 [![Coverage
 Status](https://img.shields.io/codecov/c/github/tlverse/hal9001/master.svg)](https://codecov.io/github/tlverse/hal9001?branch=master)
 [![CRAN](http://www.r-pkg.org/badges/version/hal9001)](http://www.r-pkg.org/pkg/hal9001)
@@ -97,12 +97,12 @@ hal_fit <- fit_hal(X = x, Y = y)
 #> [1] "I'm sorry, Dave. I'm afraid I can't do that."
 hal_fit$times
 #>                   user.self sys.self elapsed user.child sys.child
-#> enumerate_basis       0.001    0.000   0.001          0         0
-#> design_matrix         0.002    0.000   0.002          0         0
-#> remove_duplicates     0.004    0.000   0.004          0         0
-#> reduce_basis          0.000    0.000   0.000          0         0
-#> lasso                 0.325    0.005   0.330          0         0
-#> total                 0.332    0.005   0.337          0         0
+#> enumerate_basis       0.001     0.00   0.001          0         0
+#> design_matrix         0.001     0.00   0.002          0         0
+#> remove_duplicates     0.005     0.00   0.004          0         0
+#> reduce_basis          0.000     0.00   0.000          0         0
+#> lasso                 0.313     0.02   0.333          0         0
+#> total                 0.320     0.02   0.340          0         0
 
 # training sample prediction
 preds <- predict(hal_fit, new_data = x)

--- a/docs/articles/intro_hal9001.html
+++ b/docs/articles/intro_hal9001.html
@@ -82,7 +82,7 @@
 <a href="https://nimahejazi.org">Nima Hejazi</a> and <a href="https://github.com/jeremyrcoyle">Jeremy Coyle</a>
 </h4>
             
-            <h4 class="date">2020-06-23</h4>
+            <h4 class="date">2020-06-25</h4>
       
       <small class="dont-index">Source: <a href="https://github.com/tlverse/hal9001/blob/master/vignettes/intro_hal9001.Rmd"><code>vignettes/intro_hal9001.Rmd</code></a></small>
       <div class="hidden name"><code>intro_hal9001.Rmd</code></div>
@@ -152,12 +152,12 @@
 <pre><code>## [1] "Without your space helmet, Dave. You're going to find that rather difficult."</code></pre>
 <div class="sourceCode" id="cb11"><html><body><pre class="r"><span class="no">hal_fit</span>$<span class="no">times</span></pre></body></html></div>
 <pre><code>##                   user.self sys.self elapsed user.child sys.child
-## enumerate_basis       0.005    0.000   0.005          0         0
-## design_matrix         0.014    0.003   0.018          0         0
-## remove_duplicates     0.010    0.001   0.010          0         0
+## enumerate_basis       0.006    0.000   0.006          0         0
+## design_matrix         0.021    0.000   0.021          0         0
+## remove_duplicates     0.011    0.000   0.012          0         0
 ## reduce_basis          0.000    0.000   0.000          0         0
-## lasso                 0.817    0.008   0.825          0         0
-## total                 0.846    0.012   0.858          0         0</code></pre>
+## lasso                 0.922    0.008   0.930          0         0
+## total                 0.960    0.008   0.969          0         0</code></pre>
 <div class="sourceCode" id="cb13"><html><body><pre class="r"><span class="no">hal_fit</span></pre></body></html></div>
 <pre><code>## $call
 ## fit_hal(X = x, Y = y, fit_type = "glmnet")
@@ -16416,12 +16416,12 @@
 ## 
 ## $times
 ##                   user.self sys.self elapsed user.child sys.child
-## enumerate_basis       0.005    0.000   0.005          0         0
-## design_matrix         0.014    0.003   0.018          0         0
-## remove_duplicates     0.010    0.001   0.010          0         0
+## enumerate_basis       0.006    0.000   0.006          0         0
+## design_matrix         0.021    0.000   0.021          0         0
+## remove_duplicates     0.011    0.000   0.012          0         0
 ## reduce_basis          0.000    0.000   0.000          0         0
-## lasso                 0.817    0.008   0.825          0         0
-## total                 0.846    0.012   0.858          0         0
+## lasso                 0.922    0.008   0.930          0         0
+## total                 0.960    0.008   0.969          0         0
 ## 
 ## $lambda_star
 ## [1] 0.01537728
@@ -16566,11 +16566,11 @@
 <div class="sourceCode" id="cb18"><html><body><pre class="r"><span class="no">hal_fit_reduced</span>$<span class="no">times</span></pre></body></html></div>
 <pre><code>##                   user.self sys.self elapsed user.child sys.child
 ## enumerate_basis       0.004        0   0.004          0         0
-## design_matrix         0.017        0   0.018          0         0
-## remove_duplicates     0.007        0   0.007          0         0
-## reduce_basis          0.006        0   0.005          0         0
-## lasso                 2.144        0   2.143          0         0
-## total                 2.172        0   2.172          0         0</code></pre>
+## design_matrix         0.017        0   0.016          0         0
+## remove_duplicates     0.006        0   0.007          0         0
+## reduce_basis          0.005        0   0.004          0         0
+## lasso                 2.081        0   2.081          0         0
+## total                 2.108        0   2.108          0         0</code></pre>
 <p>In the above, all basis functions with fewer than 7.0710678% of observations meeting the criterion imposed are automatically removed prior to the Lasso step of fitting the HAL regression. The results appear below</p>
 <div class="sourceCode" id="cb20"><html><body><pre class="r"><span class="no">hal_fit_reduced</span></pre></body></html></div>
 <pre><code>## $call
@@ -32664,11 +32664,11 @@
 ## $times
 ##                   user.self sys.self elapsed user.child sys.child
 ## enumerate_basis       0.004        0   0.004          0         0
-## design_matrix         0.017        0   0.018          0         0
-## remove_duplicates     0.007        0   0.007          0         0
-## reduce_basis          0.006        0   0.005          0         0
-## lasso                 2.144        0   2.143          0         0
-## total                 2.172        0   2.172          0         0
+## design_matrix         0.017        0   0.016          0         0
+## remove_duplicates     0.006        0   0.007          0         0
+## reduce_basis          0.005        0   0.004          0         0
+## lasso                 2.081        0   2.081          0         0
+## total                 2.108        0   2.108          0         0
 ## 
 ## $lambda_star
 ## [1] 0.01073374

--- a/docs/index.html
+++ b/docs/index.html
@@ -135,12 +135,12 @@
 <span class="co">#&gt; [1] "I'm sorry, Dave. I'm afraid I can't do that."</span>
 <span class="no">hal_fit</span>$<span class="no">times</span>
 <span class="co">#&gt;                   user.self sys.self elapsed user.child sys.child</span>
-<span class="co">#&gt; enumerate_basis       0.001    0.000   0.001          0         0</span>
-<span class="co">#&gt; design_matrix         0.002    0.000   0.002          0         0</span>
-<span class="co">#&gt; remove_duplicates     0.004    0.000   0.004          0         0</span>
-<span class="co">#&gt; reduce_basis          0.000    0.000   0.000          0         0</span>
-<span class="co">#&gt; lasso                 0.325    0.005   0.330          0         0</span>
-<span class="co">#&gt; total                 0.332    0.005   0.337          0         0</span>
+<span class="co">#&gt; enumerate_basis       0.001     0.00   0.001          0         0</span>
+<span class="co">#&gt; design_matrix         0.001     0.00   0.002          0         0</span>
+<span class="co">#&gt; remove_duplicates     0.005     0.00   0.004          0         0</span>
+<span class="co">#&gt; reduce_basis          0.000     0.00   0.000          0         0</span>
+<span class="co">#&gt; lasso                 0.313     0.02   0.333          0         0</span>
+<span class="co">#&gt; total                 0.320     0.02   0.340          0         0</span>
 
 <span class="co"># training sample prediction</span>
 <span class="no">preds</span> <span class="kw">&lt;-</span> <span class="fu"><a href="https://rdrr.io/r/stats/predict.html">predict</a></span>(<span class="no">hal_fit</span>, <span class="kw">new_data</span> <span class="kw">=</span> <span class="no">x</span>)
@@ -251,7 +251,7 @@
 <h2>Dev status</h2>
 <ul class="list-unstyled">
 <li><a href="https://travis-ci.org/tlverse/hal9001"><img src="https://travis-ci.org/tlverse/hal9001.svg?branch=master" alt="Travis-CI Build Status"></a></li>
-<li><a href="https://ci.appveyor.com/project/jeremyrcoyle/hal9001"><img src="https://ci.appveyor.com/api/projects/status/github/jeremyrcoyle/hal9001?branch=master&amp;svg=true" alt="AppVeyor Build Status"></a></li>
+<li><a href="https://ci.appveyor.com/project/tlverse/hal9001"><img src="https://ci.appveyor.com/api/projects/status/github/tlverse/hal9001?branch=master&amp;svg=true" alt="AppVeyor Build Status"></a></li>
 <li><a href="https://codecov.io/github/tlverse/hal9001?branch=master"><img src="https://img.shields.io/codecov/c/github/tlverse/hal9001/master.svg" alt="Coverage Status"></a></li>
 <li><a href="http://www.r-pkg.org/pkg/hal9001"><img src="http://www.r-pkg.org/badges/version/hal9001" alt="CRAN"></a></li>
 <li><a href="https://CRAN.R-project.org/package=hal9001"><img src="https://cranlogs.r-pkg.org/badges/hal9001" alt="CRAN downloads"></a></li>

--- a/docs/pkgdown.yml
+++ b/docs/pkgdown.yml
@@ -3,7 +3,7 @@ pkgdown: 1.5.1
 pkgdown_sha: ~
 articles:
   intro_hal9001: intro_hal9001.html
-last_built: 2020-06-24T02:12Z
+last_built: 2020-06-25T20:08Z
 urls:
   reference: https://tlverse.org/hal9001/reference
   article: https://tlverse.org/hal9001/articles

--- a/man/predict.hal9001.Rd
+++ b/man/predict.hal9001.Rd
@@ -37,7 +37,7 @@ Method for computing and extracting predictions from fits of the
 \note{
 This prediction method does not function similarly to the equivalent
  method from \pkg{glmnet}. In particular, this procedure will NOT return a
- subset of lambdas originally specified in callingo \code{\link{fit_hal}}
+ subset of lambdas originally specified in calling \code{\link{fit_hal}}
  nor result in re-fitting. Instead, it will return predictions for all of
  the lambdas specified in the call to \code{\link{fit_hal}} that constructs
  \code{object}, when \code{cv_select = FALSE}. When \code{cv_select = TRUE},

--- a/tests/testthat/test-interpretation.R
+++ b/tests/testthat/test-interpretation.R
@@ -1,0 +1,100 @@
+context("Unit test for interpreting model coefficients.")
+library(data.table)
+set.seed(45791)
+
+n <- 50
+p <- 3
+x <- matrix(rnorm(n * p), n, p)
+y <- sin(x[, 1]) + sin(x[, 2]) + rnorm(n, mean = 0, sd = 0.2)
+
+################################################################################
+# check that coefficients can be interpreted in terms of the basis
+################################################################################
+
+hal_fit <- fit_hal(X = x, Y = y, yolo = FALSE)
+basis_list <- hal_fit$basis_list
+
+coefs <- as.vector(coef(hal_fit$hal_lasso))
+coefs_no_intercept <- coefs[-1]
+
+no.dups <- sum(unlist(lapply(hal_fit$copy_map, function(x) length(x)-1)))
+test_that("Basis list can be paired to coefficients with copy map", {
+  expect_equal(length(basis_list)-no.dups, length(coefs_no_intercept))
+})
+
+coefs_summary_list <- lapply(seq_along(hal_fit$copy_map), function(copy_map_idx){
+  coef <- coefs_no_intercept[copy_map_idx]
+  
+  basis_list_idxs <- hal_fit$copy_map[[copy_map_idx]] # indices of duplicates
+  basis_dups <- basis_list[basis_list_idxs]
+  
+  do.call(rbind, lapply(seq_along(basis_dups), function(i){
+      data.table(
+        coef_idx = copy_map_idx, # coefficient index
+        coef, # coefficient
+        basis_list_idx = basis_list_idxs[i], # basis list index
+        col_idx = basis_dups[[i]]$cols, # column number in x 
+        col_cutoff = basis_dups[[i]]$cutoffs # coefficient index
+      ) 
+    }))
+})
+coefs_summary <- do.call(rbind, coefs_summary_list)
+
+test_that("Copy map successfully paired basis list with coefficients", {
+  expect_equal(length(unique(coefs_summary$coef_idx)), 
+               length(coefs_no_intercept))
+  expect_equal(length(unique(coefs_summary$coef_idx)), 
+               length(unique(coefs_no_intercept)))
+  expect_equal(length(unique(coefs_summary$basis_list_idx)), 
+               length(basis_list))
+})
+
+################################################################################
+# similar check for a reduced basis list + show  how to interpret only nonzero
+################################################################################
+
+hal_fit_reduced <- fit_hal(X = x, Y = y, reduce_basis = 1 / sqrt(n))
+
+basis_list <- hal_fit_reduced$basis_list
+
+coefs <- as.vector(coef(hal_fit_reduced$hal_lasso))
+coefs_no_intercept <- coefs[-1]
+
+no.dups <- sum(unlist(lapply(hal_fit_reduced$copy_map, function(x) length(x)-1)))
+
+test_that("Basis list can be paired to nonzero coefficients with copy map", {
+  expect_equal(length(basis_list)-no.dups, length(coefs_no_intercept))
+})
+
+# only consider the nonzero coefficients when creating the summary
+nonzero_coef_idxs <- which(coefs_no_intercept != 0)
+nonzero_copy_map <- hal_fit_reduced$copy_map[nonzero_coef_idxs]
+
+coefs_summary_list <- lapply(seq_along(nonzero_copy_map), function(map_idx){
+  coef_idx <- nonzero_coef_idxs[map_idx]
+  coef <- coefs_no_intercept[coef_idx]
+  
+  basis_list_idxs <- nonzero_copy_map[[map_idx]] # indices of duplicates
+  basis_dups <- basis_list[basis_list_idxs]
+  
+  do.call(rbind, lapply(seq_along(basis_dups), function(i){
+    data.table(
+      coef_idx, # coefficient index
+      coef, # coefficient
+      basis_list_idx = basis_list_idxs[i], # basis list index
+      col_idx = basis_dups[[i]]$cols, # column number in x 
+      col_cutoff = basis_dups[[i]]$cutoffs # coefficient index
+    ) 
+  }))
+})
+nonzero_coefs_summary <- do.call(rbind, coefs_summary_list)
+
+test_that("Copy map successfully paired reduced basis list with nonzero coefficients", {
+  expect_equal(length(unique(coefs_summary$coef_idx)), 
+               length(nonzero_coef_idxs))
+  expect_equal(length(unique(coefs_summary$coef_idx)), 
+               length(unique(coefs_no_intercept[nonzero_coef_idxs])))
+  expect_equal(length(unique(coefs_summary$basis_list_idx)), 
+               length(basis_list))
+  expect_equal(sum(nonzero_coefs_summary$coef == 0), 0)
+})

--- a/tests/testthat/test-interpretation.R
+++ b/tests/testthat/test-interpretation.R
@@ -68,7 +68,7 @@ coefs_summary <- rbind(intercept, coefs_basis_summary)
 # similar check for a reduced basis list + show  how to interpret only nonzero
 ################################################################################
 
-hal_fit_reduced <- fit_hal(X = x, Y = y, reduce_basis = 1 / sqrt(n), yolo = F)
+hal_fit_reduced <- fit_hal(X = x, Y = y, reduce_basis = 1 / sqrt(n))
 basis_list <- hal_fit_reduced$basis_list
 
 coefs <- as.vector(coef(hal_fit_reduced$hal_lasso))

--- a/tests/testthat/test-interpretation.R
+++ b/tests/testthat/test-interpretation.R
@@ -17,43 +17,51 @@ basis_list <- hal_fit$basis_list
 coefs <- as.vector(coef(hal_fit$hal_lasso))
 coefs_no_intercept <- coefs[-1]
 
-no.dups <- sum(unlist(lapply(hal_fit$copy_map, function(x) length(x)-1)))
+no.dups <- sum(unlist(lapply(hal_fit$copy_map, function(x) length(x) - 1)))
 
 test_that("Basis list can be paired to coefficients with copy map", {
-  expect_equal(length(basis_list)-no.dups, length(coefs_no_intercept))
+  expect_equal(length(basis_list) - no.dups, length(coefs_no_intercept))
 })
 
-coefs_summary_list <- lapply(seq_along(hal_fit$copy_map), function(copy_map_idx){
+coefs_summary_list <- lapply(seq_along(hal_fit$copy_map), function(copy_map_idx) {
   coef <- coefs_no_intercept[copy_map_idx]
 
   basis_list_idxs <- hal_fit$copy_map[[copy_map_idx]] # indices of duplicates
   basis_dups <- basis_list[basis_list_idxs]
 
-  do.call(rbind, lapply(seq_along(basis_dups), function(i){
-      data.table(
-        coef_idx = copy_map_idx+1, # coefficient index (incorporate intercept)
-        coef, # coefficient
-        basis_list_idx = basis_list_idxs[i], # basis list index
-        col_idx = basis_dups[[i]]$cols, # column number in x
-        col_cutoff = basis_dups[[i]]$cutoffs # coefficient index
-      )
-    }))
+  do.call(rbind, lapply(seq_along(basis_dups), function(i) {
+    data.table(
+      coef_idx = copy_map_idx + 1, # coefficient index (incorporate intercept)
+      coef, # coefficient
+      basis_list_idx = basis_list_idxs[i], # basis list index
+      col_idx = basis_dups[[i]]$cols, # column number in x
+      col_cutoff = basis_dups[[i]]$cutoffs # coefficient index
+    )
+  }))
 })
 
 coefs_basis_summary <- do.call(rbind, coefs_summary_list)
 
 test_that("Copy map successfully paired basis list with coefficients", {
-  expect_equal(length(unique(coefs_basis_summary$coef_idx)),
-               length(coefs_no_intercept))
-  expect_equal(length(unique(coefs_basis_summary$coef)),
-               length(unique(coefs_no_intercept)))
-  expect_equal(length(unique(coefs_basis_summary$basis_list_idx)),
-               length(basis_list))
+  expect_equal(
+    length(unique(coefs_basis_summary$coef_idx)),
+    length(coefs_no_intercept)
+  )
+  expect_equal(
+    length(unique(coefs_basis_summary$coef)),
+    length(unique(coefs_no_intercept))
+  )
+  expect_equal(
+    length(unique(coefs_basis_summary$basis_list_idx)),
+    length(basis_list)
+  )
 })
 
 # add intercept for completeness
-intercept <- data.table(coef_idx = 1, coef = coefs[1],
-                        basis_list_idx = NA, col_idx = NA, col_cutoff = NA)
+intercept <- data.table(
+  coef_idx = 1, coef = coefs[1],
+  basis_list_idx = NA, col_idx = NA, col_cutoff = NA
+)
 coefs_summary <- rbind(intercept, coefs_basis_summary)
 
 ################################################################################
@@ -66,26 +74,26 @@ basis_list <- hal_fit_reduced$basis_list
 coefs <- as.vector(coef(hal_fit_reduced$hal_lasso))
 coefs_no_intercept <- coefs[-1]
 
-no.dups <- sum(unlist(lapply(hal_fit_reduced$copy_map, function(x) length(x)-1)))
+no.dups <- sum(unlist(lapply(hal_fit_reduced$copy_map, function(x) length(x) - 1)))
 
 test_that("Basis list can be paired to nonzero coefficients with copy map", {
-  expect_equal(length(basis_list)-no.dups, length(coefs_no_intercept))
+  expect_equal(length(basis_list) - no.dups, length(coefs_no_intercept))
 })
 
 # only consider the nonzero coefficients when creating the summary
 nonzero_coef_idxs <- which(coefs_no_intercept != 0)
 nonzero_copy_map <- hal_fit_reduced$copy_map[nonzero_coef_idxs]
 
-coefs_summary_list <- lapply(seq_along(nonzero_copy_map), function(map_idx){
+coefs_summary_list <- lapply(seq_along(nonzero_copy_map), function(map_idx) {
   coef_idx <- nonzero_coef_idxs[map_idx]
   coef <- coefs_no_intercept[coef_idx]
 
   basis_list_idxs <- nonzero_copy_map[[map_idx]] # indices of duplicates
   basis_dups <- basis_list[basis_list_idxs]
 
-  do.call(rbind, lapply(seq_along(basis_dups), function(i){
+  do.call(rbind, lapply(seq_along(basis_dups), function(i) {
     data.table(
-      coef_idx = coef_idx+1, # coefficient index (incorporate intercept)
+      coef_idx = coef_idx + 1, # coefficient index (incorporate intercept)
       coef, # coefficient
       basis_list_idx = basis_list_idxs[i], # basis list index
       col_idx = basis_dups[[i]]$cols, # column number in x
@@ -96,49 +104,69 @@ coefs_summary_list <- lapply(seq_along(nonzero_copy_map), function(map_idx){
 nonzero_coefs_summary <- do.call(rbind, coefs_summary_list)
 
 test_that("Copy map successfully paired reduced basis list with nonzero coefficients", {
-  expect_equal(length(unique(nonzero_coefs_summary$coef_idx)),
-               length(nonzero_coef_idxs))
-  expect_equal(length(unique(nonzero_coefs_summary$coef)),
-               length(unique(coefs_no_intercept[nonzero_coef_idxs])))
-  expect_equal(length(unique(nonzero_coefs_summary$basis_list_idx)),
-               length(unlist(nonzero_copy_map)))
+  expect_equal(
+    length(unique(nonzero_coefs_summary$coef_idx)),
+    length(nonzero_coef_idxs)
+  )
+  expect_equal(
+    length(unique(nonzero_coefs_summary$coef)),
+    length(unique(coefs_no_intercept[nonzero_coef_idxs]))
+  )
+  expect_equal(
+    length(unique(nonzero_coefs_summary$basis_list_idx)),
+    length(unlist(nonzero_copy_map))
+  )
   expect_equal(sum(nonzero_coefs_summary$coef == 0), 0)
 })
 
 # add intercept for completeness
-intercept <- data.table(coef_idx = 1, coef = coefs[1],
-                        basis_list_idx = NA, col_idx = NA, col_cutoff = NA)
+intercept <- data.table(
+  coef_idx = 1, coef = coefs[1],
+  basis_list_idx = NA, col_idx = NA, col_cutoff = NA
+)
 nonzero_coefs_summary <- rbind(intercept, nonzero_coefs_summary)
 
 ##### to interpret wrt column names and basis function:
 colnames(x) <- c("x1", "x2", "x3")
 xnames <- data.table(col_idx = 1:ncol(x), col_names = colnames(x))
-init_desc_summary <- merge(nonzero_coefs_summary, xnames, by = "col_idx",
-                           all.x = TRUE)
-init_desc_summary$term <- paste0("I(", init_desc_summary$col_names, " >= ",
-                                 round(init_desc_summary$col_cutoff, 3), ")")
-term_tbl <- stats::aggregate(term ~ basis_list_idx, data = init_desc_summary,
-                             paste, collapse = " * ")
+init_desc_summary <- merge(nonzero_coefs_summary, xnames,
+  by = "col_idx",
+  all.x = TRUE
+)
+init_desc_summary$term <- paste0(
+  "I(", init_desc_summary$col_names, " >= ",
+  round(init_desc_summary$col_cutoff, 3), ")"
+)
+term_tbl <- stats::aggregate(term ~ basis_list_idx,
+  data = init_desc_summary,
+  paste, collapse = " * "
+)
 redundant <- c("term", "col_cutoff", "col_names", "col_idx")
-init_desc_summary <- set(init_desc_summary, ,redundant, NULL)
+init_desc_summary <- set(init_desc_summary, , redundant, NULL)
 init_desc_summary <- unique(init_desc_summary)
-desc_summary <- merge(term_tbl, init_desc_summary, by = "basis_list_idx",
-                      all.x = TRUE, all.y = FALSE)
+desc_summary <- merge(term_tbl, init_desc_summary,
+  by = "basis_list_idx",
+  all.x = TRUE, all.y = FALSE
+)
 
 # could summarize by adding the duplicated terms in a single column
-coef_tbl <- stats::aggregate(term ~ coef_idx, data = desc_summary,
-                             paste, collapse = "  OR  ")
+coef_tbl <- stats::aggregate(term ~ coef_idx,
+  data = desc_summary,
+  paste, collapse = "  OR  "
+)
 
 # alternative could summarize by creating new term column for each duplicate
-list_coef_tbl <- lapply(unique(desc_summary$coef_idx), function(coef_idx){
-  coef_terms <- desc_summary[desc_summary$coef_idx == coef_idx,]
+list_coef_tbl <- lapply(unique(desc_summary$coef_idx), function(coef_idx) {
+  coef_terms <- desc_summary[desc_summary$coef_idx == coef_idx, ]
   terms <- matrix(nrow = 1, ncol = nrow(coef_terms))
-  for(i in 1:nrow(coef_terms)){
-    terms[,i] <- coef_terms[i,]$term
+  for (i in 1:nrow(coef_terms)) {
+    terms[, i] <- coef_terms[i, ]$term
   }
   coef_tbl <- data.table(coef = unique(coef_terms$coef), data.table(terms))
   return(coef_tbl)
 })
 coef_tbl <- rbindlist(list_coef_tbl, fill = TRUE)
-colnames(coef_tbl) <- c("coef", "term",
-                        paste0("term_duplicate_1", seq(1:(ncol(coef_tbl)-2))))
+colnames(coef_tbl) <- c(
+  "coef", "term",
+  paste0("term_duplicate_1", seq(1:(ncol(coef_tbl) - 2)))
+)

--- a/tests/testthat/test-interpretation.R
+++ b/tests/testthat/test-interpretation.R
@@ -43,7 +43,7 @@ coefs_summary <- do.call(rbind, coefs_summary_list)
 test_that("Copy map successfully paired basis list with coefficients", {
   expect_equal(length(unique(coefs_summary$coef_idx)), 
                length(coefs_no_intercept))
-  expect_equal(length(unique(coefs_summary$coef_idx)), 
+  expect_equal(length(unique(coefs_summary$coef)), 
                length(unique(coefs_no_intercept)))
   expect_equal(length(unique(coefs_summary$basis_list_idx)), 
                length(basis_list))
@@ -90,11 +90,11 @@ coefs_summary_list <- lapply(seq_along(nonzero_copy_map), function(map_idx){
 nonzero_coefs_summary <- do.call(rbind, coefs_summary_list)
 
 test_that("Copy map successfully paired reduced basis list with nonzero coefficients", {
-  expect_equal(length(unique(coefs_summary$coef_idx)), 
+  expect_equal(length(unique(nonzero_coefs_summary$coef_idx)), 
                length(nonzero_coef_idxs))
-  expect_equal(length(unique(coefs_summary$coef_idx)), 
+  expect_equal(length(unique(nonzero_coefs_summary$coef)), 
                length(unique(coefs_no_intercept[nonzero_coef_idxs])))
-  expect_equal(length(unique(coefs_summary$basis_list_idx)), 
-               length(basis_list))
+  expect_equal(length(unique(nonzero_coefs_summary$basis_list_idx)), 
+               length(unlist(nonzero_copy_map)))
   expect_equal(sum(nonzero_coefs_summary$coef == 0), 0)
 })

--- a/tests/testthat/test-interpretation.R
+++ b/tests/testthat/test-interpretation.R
@@ -18,43 +18,49 @@ coefs <- as.vector(coef(hal_fit$hal_lasso))
 coefs_no_intercept <- coefs[-1]
 
 no.dups <- sum(unlist(lapply(hal_fit$copy_map, function(x) length(x)-1)))
+
 test_that("Basis list can be paired to coefficients with copy map", {
   expect_equal(length(basis_list)-no.dups, length(coefs_no_intercept))
 })
 
 coefs_summary_list <- lapply(seq_along(hal_fit$copy_map), function(copy_map_idx){
   coef <- coefs_no_intercept[copy_map_idx]
-  
+
   basis_list_idxs <- hal_fit$copy_map[[copy_map_idx]] # indices of duplicates
   basis_dups <- basis_list[basis_list_idxs]
-  
+
   do.call(rbind, lapply(seq_along(basis_dups), function(i){
       data.table(
-        coef_idx = copy_map_idx, # coefficient index
+        coef_idx = copy_map_idx+1, # coefficient index (incorporate intercept)
         coef, # coefficient
         basis_list_idx = basis_list_idxs[i], # basis list index
-        col_idx = basis_dups[[i]]$cols, # column number in x 
+        col_idx = basis_dups[[i]]$cols, # column number in x
         col_cutoff = basis_dups[[i]]$cutoffs # coefficient index
-      ) 
+      )
     }))
 })
-coefs_summary <- do.call(rbind, coefs_summary_list)
+
+coefs_basis_summary <- do.call(rbind, coefs_summary_list)
 
 test_that("Copy map successfully paired basis list with coefficients", {
-  expect_equal(length(unique(coefs_summary$coef_idx)), 
+  expect_equal(length(unique(coefs_basis_summary$coef_idx)),
                length(coefs_no_intercept))
-  expect_equal(length(unique(coefs_summary$coef)), 
+  expect_equal(length(unique(coefs_basis_summary$coef)),
                length(unique(coefs_no_intercept)))
-  expect_equal(length(unique(coefs_summary$basis_list_idx)), 
+  expect_equal(length(unique(coefs_basis_summary$basis_list_idx)),
                length(basis_list))
 })
+
+# add intercept for completeness
+intercept <- data.table(coef_idx = 1, coef = coefs[1],
+                        basis_list_idx = NA, col_idx = NA, col_cutoff = NA)
+coefs_summary <- rbind(intercept, coefs_basis_summary)
 
 ################################################################################
 # similar check for a reduced basis list + show  how to interpret only nonzero
 ################################################################################
 
-hal_fit_reduced <- fit_hal(X = x, Y = y, reduce_basis = 1 / sqrt(n))
-
+hal_fit_reduced <- fit_hal(X = x, Y = y, reduce_basis = 1 / sqrt(n), yolo = F)
 basis_list <- hal_fit_reduced$basis_list
 
 coefs <- as.vector(coef(hal_fit_reduced$hal_lasso))
@@ -73,28 +79,66 @@ nonzero_copy_map <- hal_fit_reduced$copy_map[nonzero_coef_idxs]
 coefs_summary_list <- lapply(seq_along(nonzero_copy_map), function(map_idx){
   coef_idx <- nonzero_coef_idxs[map_idx]
   coef <- coefs_no_intercept[coef_idx]
-  
+
   basis_list_idxs <- nonzero_copy_map[[map_idx]] # indices of duplicates
   basis_dups <- basis_list[basis_list_idxs]
-  
+
   do.call(rbind, lapply(seq_along(basis_dups), function(i){
     data.table(
-      coef_idx, # coefficient index
+      coef_idx = coef_idx+1, # coefficient index (incorporate intercept)
       coef, # coefficient
       basis_list_idx = basis_list_idxs[i], # basis list index
-      col_idx = basis_dups[[i]]$cols, # column number in x 
+      col_idx = basis_dups[[i]]$cols, # column number in x
       col_cutoff = basis_dups[[i]]$cutoffs # coefficient index
-    ) 
+    )
   }))
 })
 nonzero_coefs_summary <- do.call(rbind, coefs_summary_list)
 
 test_that("Copy map successfully paired reduced basis list with nonzero coefficients", {
-  expect_equal(length(unique(nonzero_coefs_summary$coef_idx)), 
+  expect_equal(length(unique(nonzero_coefs_summary$coef_idx)),
                length(nonzero_coef_idxs))
-  expect_equal(length(unique(nonzero_coefs_summary$coef)), 
+  expect_equal(length(unique(nonzero_coefs_summary$coef)),
                length(unique(coefs_no_intercept[nonzero_coef_idxs])))
-  expect_equal(length(unique(nonzero_coefs_summary$basis_list_idx)), 
+  expect_equal(length(unique(nonzero_coefs_summary$basis_list_idx)),
                length(unlist(nonzero_copy_map)))
   expect_equal(sum(nonzero_coefs_summary$coef == 0), 0)
 })
+
+# add intercept for completeness
+intercept <- data.table(coef_idx = 1, coef = coefs[1],
+                        basis_list_idx = NA, col_idx = NA, col_cutoff = NA)
+nonzero_coefs_summary <- rbind(intercept, nonzero_coefs_summary)
+
+##### to interpret wrt column names and basis function:
+colnames(x) <- c("x1", "x2", "x3")
+xnames <- data.table(col_idx = 1:ncol(x), col_names = colnames(x))
+init_desc_summary <- merge(nonzero_coefs_summary, xnames, by = "col_idx",
+                           all.x = TRUE)
+init_desc_summary$term <- paste0("I(", init_desc_summary$col_names, " >= ",
+                                 round(init_desc_summary$col_cutoff, 3), ")")
+term_tbl <- stats::aggregate(term ~ basis_list_idx, data = init_desc_summary,
+                             paste, collapse = " * ")
+redundant <- c("term", "col_cutoff", "col_names", "col_idx")
+init_desc_summary <- set(init_desc_summary, ,redundant, NULL)
+init_desc_summary <- unique(init_desc_summary)
+desc_summary <- merge(term_tbl, init_desc_summary, by = "basis_list_idx",
+                      all.x = TRUE, all.y = FALSE)
+
+# could summarize by adding the duplicated terms in a single column
+coef_tbl <- stats::aggregate(term ~ coef_idx, data = desc_summary,
+                             paste, collapse = "  OR  ")
+
+# alternative could summarize by creating new term column for each duplicate
+list_coef_tbl <- lapply(unique(desc_summary$coef_idx), function(coef_idx){
+  coef_terms <- desc_summary[desc_summary$coef_idx == coef_idx,]
+  terms <- matrix(nrow = 1, ncol = nrow(coef_terms))
+  for(i in 1:nrow(coef_terms)){
+    terms[,i] <- coef_terms[i,]$term
+  }
+  coef_tbl <- data.table(coef = unique(coef_terms$coef), data.table(terms))
+  return(coef_tbl)
+})
+coef_tbl <- rbindlist(list_coef_tbl, fill = TRUE)
+colnames(coef_tbl) <- c("coef", "term",
+                        paste0("term_duplicate_1", seq(1:(ncol(coef_tbl)-2))))

--- a/tests/testthat/test-interpretation.R
+++ b/tests/testthat/test-interpretation.R
@@ -154,6 +154,7 @@ coef_tbl <- stats::aggregate(term ~ coef_idx,
   data = desc_summary,
   paste, collapse = "  OR  "
 )
+coef_tbl$coef <- round(coef_tbl$coef, 3)
 
 # alternative could summarize by creating new term column for each duplicate
 list_coef_tbl <- lapply(unique(desc_summary$coef_idx), function(coef_idx) {
@@ -162,11 +163,11 @@ list_coef_tbl <- lapply(unique(desc_summary$coef_idx), function(coef_idx) {
   for (i in 1:nrow(coef_terms)) {
     terms[, i] <- coef_terms[i, ]$term
   }
-  coef_tbl <- data.table(coef = unique(coef_terms$coef), data.table(terms))
+  coef_tbl <- data.table(coef = round(unique(coef_terms$coef), 3), data.table(terms))
   return(coef_tbl)
 })
 coef_tbl <- rbindlist(list_coef_tbl, fill = TRUE)
 colnames(coef_tbl) <- c(
   "coef", "term",
-  paste0("term_duplicate_1", seq(1:(ncol(coef_tbl) - 2)))
+  paste0("term_duplicate_", seq(1:(ncol(coef_tbl) - 2)))
 )

--- a/tests/testthat/test-reduce_basis_filter.R
+++ b/tests/testthat/test-reduce_basis_filter.R
@@ -156,3 +156,7 @@ test_that("Basis reduction passes fewer beta estimates to the lasso model", {
 test_that("Predictions are not too different when reducing basis functions", {
   expect_lt(mean((hal_pred_full - hal_pred_reduced)^2), 0.01)
 })
+
+# ensure hal fit with reduce_basis works with new data for prediction
+newx <-  matrix(rnorm(n * p), n, p)
+hal_pred_reduced_newx <- predict(hal_fit_reduced, new_data = newx)

--- a/tests/testthat/test-reduce_basis_filter.R
+++ b/tests/testthat/test-reduce_basis_filter.R
@@ -158,5 +158,5 @@ test_that("Predictions are not too different when reducing basis functions", {
 })
 
 # ensure hal fit with reduce_basis works with new data for prediction
-newx <-  matrix(rnorm(n * p), n, p)
+newx <- matrix(rnorm(n * p), n, p)
 hal_pred_reduced_newx <- predict(hal_fit_reduced, new_data = newx)


### PR DESCRIPTION
A few fixes related to filtering and interpretation. 

- Extended functionality to support predictions on new data (i.e., not used in training) when `reduce_basis` is supplied in `fit_hal`. 
- Moved `copy_map` filtering of `x_basis` after `reduce_basis` filtering of `x_basis`, and `reduce_basis` now filters `basis_list` as well. 
- Added test for pairing the returned basis list with the coefficients. This pairing allows interpretation of the coefficients in terms of the cutoffs of the predictor values. 