### PR TITLE
Minor change to binning function

### DIFF
--- a/R/make_basis.R
+++ b/R/make_basis.R
@@ -323,12 +323,11 @@ quantizer <- function(X, bins) {
       return(rep(0, length(x)))
     }
     if (bins == 1) {
-      return(rep(stats::median(x), length(x)))
+      return(rep(min(x), length(x)))
     }
-    p <- max(1 - (25 / nrow(X)), 0.98)
-    quants <- seq(0, 0.98, length.out = bins)
+    p <- max(1 - (20 / nrow(X)), 0.98)
+    quants <- seq(0, p, length.out = bins)
     q <- stats::quantile(x, quants)
-
     nearest <- findInterval(x, q)
     x <- q[nearest]
     return(x)


### PR DESCRIPTION
Minor change to how binning is performed when num_knots = 1. Now ensures that minimal knot is chosen when num_knots = 1 so that HAL agrees with main term glmnet when smoothness_orders=1 and num_knots=1.