### PR TITLE
Fixing mismatched column names in `predict.hal9001` method

### DIFF
--- a/R/predict.R
+++ b/R/predict.R
@@ -54,7 +54,7 @@ predict.hal9001 <- function(object,
     if (is.null(colnames(new_data))) {
       warning("No column names found in the `new_data` matrix.")
       assertthat::assert_that(ncol(new_data) >= length(object$X_colnames),
-                              msg = "The dimension of `new_data` matrix is inconsistent with the X_colnames in fit_hal")
+                              msg = "The dimension of `new_data` matrix is inconsistent with `hal_fit$X_colnames`")
       warning(paste("Setting the first", length(hal_fit$X_colnames), "columns in `new_data` matrix as `hal_fit$X_colnames` for prediction"))
       colnames(new_data) <- object$X_colnames
     }

--- a/tests/testthat/test-predict.R
+++ b/tests/testthat/test-predict.R
@@ -31,3 +31,12 @@ colnames(x_new) <- c("x1", "x3", "x4")
 test_that("Report an error when `new_data` is a data frame but its column names are not found in hal_fit$X_colnames", {
   expect_error(predict(hal_fit, new_data = data.frame(x_new)), "x2 in hal_fit is/are not found in new_data")
 })
+
+x_new_matched <- data.frame(matrix(rnorm(n * p), n, p))
+colnames(x_new_matched) <- c("x1", "x2", "x3")
+x_new_unmatched <- cbind(data.frame("x4" = matrix(rnorm(n * 1), n, 1)), x_new_matched)
+
+test_that("HAL prediction function respects the column names of `new_data`", {
+  expect_true(all(predict(hal_fit, new_data = x_new_matched) == predict(hal_fit, new_data = x_new_unmatched)))
+})
+

--- a/tests/testthat/test-predict.R
+++ b/tests/testthat/test-predict.R
@@ -22,7 +22,7 @@ test_that("Report a warning when `new_data` is a matrix with sufficient or large
 
 x_new <- matrix(rnorm(n * p), n, p)
 colnames(x_new) <- c("x1", "x3", "x4")
-test_that("Report an error when `new_data` is a matrix but its column names are not found in hal_fit$X_colnames", {
+test_that("Report an error when `new_data` is a matrix but does not include all columns in hal_fit$X_colnames", {
   expect_error(predict(hal_fit, new_data = x_new), "x2 in hal_fit is/are not found in new_data")
 })
 

--- a/tests/testthat/test-predict.R
+++ b/tests/testthat/test-predict.R
@@ -28,14 +28,13 @@ test_that("Report an error when `new_data` is a matrix but its column names are 
 
 x_new <- data.frame(matrix(rnorm(n * p), n, p))
 colnames(x_new) <- c("x1", "x3", "x4")
-test_that("Report an error when `new_data` is a data frame but its column names are not found in hal_fit$X_colnames", {
+test_that("Report an error when `new_data` is a data frame but does not include all columns in hal_fit$X_colnames", {
   expect_error(predict(hal_fit, new_data = data.frame(x_new)), "x2 in hal_fit is/are not found in new_data")
 })
 
 x_new_matched <- data.frame(matrix(rnorm(n * p), n, p))
 colnames(x_new_matched) <- c("x1", "x2", "x3")
 x_new_unmatched <- cbind(data.frame("x4" = matrix(rnorm(n * 1), n, 1)), x_new_matched)
-
 test_that("HAL prediction function respects the column names of `new_data`", {
   expect_true(all(predict(hal_fit, new_data = x_new_matched) == predict(hal_fit, new_data = x_new_unmatched)))
 })

--- a/tests/testthat/test-predict.R
+++ b/tests/testthat/test-predict.R
@@ -1,0 +1,33 @@
+context("Predict with HAL")
+set.seed(45791)
+
+# generate simple test data
+
+n <- 100
+p <- 3
+x <- xmat <- matrix(rnorm(n * p), n, p)
+y_prob <- plogis(3 * sin(x[, 1]) + sin(x[, 2]))
+y <- rbinom(n = n, size = 1, prob = y_prob)
+hal_fit <- fit_hal(X = x, Y = y, family = "binomial")
+
+x_new <- matrix(rnorm(n * (p - 1)), n, p - 1)
+test_that("Report an error when `new_data` is a matrix with insufficient number of columns", {
+  expect_error(predict(hal_fit, new_data = x_new))
+})
+
+x_new <- matrix(rnorm(n * p), n, p)
+test_that("Report a warning when `new_data` is a matrix with sufficient or larger number of columns but without column names", {
+  expect_warning(predict(hal_fit, new_data = x_new))
+})
+
+x_new <- matrix(rnorm(n * p), n, p)
+colnames(x_new) <- c("x1", "x3", "x4")
+test_that("Report an error when `new_data` is a matrix but its column names are not found in hal_fit$X_colnames", {
+  expect_error(predict(hal_fit, new_data = x_new), "x2 in hal_fit is/are not found in new_data")
+})
+
+x_new <- data.frame(matrix(rnorm(n * p), n, p))
+colnames(x_new) <- c("x1", "x3", "x4")
+test_that("Report an error when `new_data` is a data frame but its column names are not found in hal_fit$X_colnames", {
+  expect_error(predict(hal_fit, new_data = data.frame(x_new)), "x2 in hal_fit is/are not found in new_data")
+})


### PR DESCRIPTION
Added warning and error messages when `new_data` mismatches `hal_fit` in column names