### PR TITLE
Fix bug in formula for `h(.)` case

### DIFF
--- a/R/formula_hal9001.R
+++ b/R/formula_hal9001.R
@@ -143,6 +143,17 @@ h <- function(..., k = NULL, s = NULL, pf = 1,
     var_names <- unlist(list(...))
   }
   formula_term <- paste0("h(", paste0(var_names, collapse = ", "), ")")
+  
+  if (is.null(k)) {
+    k <- get("num_knots", envir = parent.frame())
+    k <- suppressWarnings(k + rep(0, length(var_names))) # recycle
+    k <- k[length(var_names)]
+  }
+  if (is.null(s)) {
+    s <- get("smoothness_orders", envir = parent.frame())[1]
+  }
+  
+  
   if ("." %in% var_names) {
     var_names_filled <- fill_dots(var_names, . = .)
 
@@ -175,15 +186,7 @@ h <- function(..., k = NULL, s = NULL, pf = 1,
     return(all_items)
   }
 
-  if (is.null(k)) {
-    k <- get("num_knots", envir = parent.frame())
-
-    k <- suppressWarnings(k + rep(0, length(var_names))) # recycle
-    k <- k[length(var_names)]
-  }
-  if (is.null(s)) {
-    s <- get("smoothness_orders", envir = parent.frame())[1]
-  }
+   
 
 
   # Get corresponding column indices

--- a/R/formula_hal9001.R
+++ b/R/formula_hal9001.R
@@ -145,9 +145,6 @@ h <- function(..., k = NULL, s = NULL, pf = 1,
   formula_term <- paste0("h(", paste0(var_names, collapse = ", "), ")")
   if ("." %in% var_names) {
     var_names_filled <- fill_dots(var_names, . = .)
-    if (!is.list(var_names_filled)) {
-      var_names_filled <- list(var_names_filled)
-    }
 
     all_items <- lapply(var_names_filled, function(var) {
       h(var,

--- a/tests/testthat/test-formula.R
+++ b/tests/testthat/test-formula.R
@@ -7,10 +7,11 @@ p <- 3
 X <- xmat <- matrix(rnorm(n * p), n, p)
 colnames(X) <- c("X1", "X2", "X3")
 
-smoothness_orders <- 1
-num_knots <- 3
+ 
 
 test_that("Check formula", {
+  smoothness_orders <- 1
+num_knots <- 3
   expect_true(length(h(X1)$basis_list) == num_knots)
   expect_true(h(X1)$basis_list[[1]]$orders == 1)
   expect_true(all(h(X1)$penalty.factors == 1))

--- a/tests/testthat/test-formula.R
+++ b/tests/testthat/test-formula.R
@@ -28,6 +28,10 @@ test_that("Check formula", {
   expect_true(length(setdiff(formula_hal(formula)$basis_list, (h(X1) + h(X2))$basis_list)) == 0)
   expect_true(length(formula_hal(formula, num_knots = 3)$basis_list) == length(formula_hal(formula)$basis_list))
   expect_true(length(formula_hal(formula, num_knots = 10)$basis_list) != length(formula_hal(formula)$basis_list))
+  formula <- h(.)$basis_list
+  expect_true(length(formula[[1]]$cols) == 1)
+  formula <- h(.,.)$basis_list
+  expect_true(length(formula[[1]]$cols) == 2)
 })
 
 

--- a/tests/testthat/test-formula.R
+++ b/tests/testthat/test-formula.R
@@ -28,9 +28,9 @@ test_that("Check formula", {
   expect_true(length(setdiff(formula_hal(formula)$basis_list, (h(X1) + h(X2))$basis_list)) == 0)
   expect_true(length(formula_hal(formula, num_knots = 3)$basis_list) == length(formula_hal(formula)$basis_list))
   expect_true(length(formula_hal(formula, num_knots = 10)$basis_list) != length(formula_hal(formula)$basis_list))
-  formula <- h(.)$basis_list
+  formula <- h(., k =2)$basis_list
   expect_true(length(formula[[1]]$cols) == 1)
-  formula <- h(.,.)$basis_list
+  formula <- h(.,., k =2)$basis_list
   expect_true(length(formula[[1]]$cols) == 2)
 })
 


### PR DESCRIPTION
Unfortunately, there was a bug that made h(.) generate basis functions incorrectly. This is now fixed and an additional test case has been added to the formula TestThat.