### PR TITLE
Support for multivariate outcome prediction

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -68,5 +68,5 @@ LinkingTo:
   Rcpp,
   RcppEigen
 VignetteBuilder: knitr
-RoxygenNote: 7.1.2
+RoxygenNote: 7.2.0
 Roxygen: list(markdown = TRUE)

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: hal9001
 Title: The Scalable Highly Adaptive Lasso
-Version: 0.4.4
+Version: 0.4.5
 Authors@R: c(
   person("Jeremy", "Coyle", email = "jeremyrcoyle@gmail.com",
          role = c("aut", "cre"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+# hal9001 0.4.5
+* Added multivariate outcome prediction
+
 # hal9001 0.4.4
 * Fixed bug with `prediction_bounds` (a `fit_hal` argument in `fit_control` 
   list), which would error when it was specified as a numeric vector. Also, 

--- a/R/predict.R
+++ b/R/predict.R
@@ -16,10 +16,6 @@
 #' @param offset A vector of offsets. Must be provided if provided at training.
 #' @param type Either "response" for predictions of the response, or "link" for
 #' un-transformed predictions (on the scale of the link function).
-#' @param p_reserve Sparse matrix pre-allocation proportion, which is the
-#'  anticipated proportion of 1's in the design matrix. Default value is
-#'  recommended in most settings. If a dense design matrix is expected, it
-#'  would be useful to set \code{p_reserve} to a higher value.
 #' @param ... Additional arguments passed to \code{predict} as necessary.
 #'
 #' @importFrom Matrix tcrossprod
@@ -44,10 +40,8 @@ predict.hal9001 <- function(object,
                             new_X_unpenalized = NULL,
                             offset = NULL,
                             type = c("response", "link"),
-                            p_reserve = 0.75,
                             ...) {
   type <- match.arg(type)
-  p_reserve <- pmax(pmin(p_reserve, 1), 0)
   # cast new data to matrix if not so already
   if (!is.matrix(new_data)) new_data <- as.matrix(new_data)
 
@@ -56,9 +50,7 @@ predict.hal9001 <- function(object,
   }
 
   # generate design matrix
-  pred_x_basis <- make_design_matrix(new_data, object$basis_list,
-    p_reserve = p_reserve
-  )
+  pred_x_basis <- make_design_matrix(new_data, object$basis_list)
 
   # reduce matrix of basis functions
   # pred_x_basis <- apply_copy_map(pred_x_basis, object$copy_map)
@@ -83,7 +75,7 @@ predict.hal9001 <- function(object,
   }
 
   # generate predictions
-  if (inherits(object$family, "family") || object$family != "cox") {
+  if (inherits(object$family, "family") || !object$family %in% c("cox", "mgaussian")) {
     if (ncol(object$coefs) > 1) {
       preds <- apply(object$coefs, 2, function(hal_coefs) {
         as.vector(Matrix::tcrossprod(
@@ -98,20 +90,28 @@ predict.hal9001 <- function(object,
       ) + object$coefs[1])
     }
   } else {
-    # Note: there is no intercept in the Cox model (built into the baseline
-    #       hazard and would cancel in the partial likelihood).
-    if (ncol(object$coefs) > 1) {
-      preds <- apply(object$coefs, 2, function(hal_coefs) {
-        as.vector(Matrix::tcrossprod(
+    if(object$family == "cox") {
+      # Note: there is no intercept in the Cox model (built into the baseline
+      #       hazard and would cancel in the partial likelihood).
+      # Note: there is no intercept in the Cox model (built into the baseline
+      #       hazard and would cancel in the partial likelihood).
+      if (ncol(object$coefs) > 1) {
+        preds <- apply(object$coefs, 2, function(hal_coefs) {
+          as.vector(Matrix::tcrossprod(
+            x = pred_x_basis,
+            y = hal_coefs
+          ))
+        })
+      } else {
+        preds <- as.vector(Matrix::tcrossprod(
           x = pred_x_basis,
-          y = hal_coefs
+          y = as.vector(object$coefs)
         ))
-      })
-    } else {
-      preds <- as.vector(Matrix::tcrossprod(
-        x = pred_x_basis,
-        y = as.vector(object$coefs)
-      ))
+      }
+    } else if (object$family == "mgaussian") {
+      preds <- stats::predict(
+        object$lasso_fit, newx = pred_x_basis, s = object$lambda_star
+      )
     }
   }
 
@@ -139,13 +139,23 @@ predict.hal9001 <- function(object,
   # bound predictions within observed outcome bounds if on response scale
   bounds <- object$prediction_bounds
   if (!is.null(bounds)) {
-    bounds <- sort(bounds)
-    if (is.matrix(preds)) {
-      preds <- apply(preds, 2, pmax, bounds[1])
-      preds <- apply(preds, 2, pmin, bounds[2])
+    if(object$family != "mgaussian"){
+      bounds <- sort(bounds)
+      if (is.matrix(preds)) {
+        preds <- apply(preds, 2, pmax, bounds[1])
+        preds <- apply(preds, 2, pmin, bounds[2])
+      } else {
+        preds <- pmax(bounds[1], preds)
+        preds <- pmin(preds, bounds[2])
+      }
     } else {
-      preds <- pmax(bounds[1], preds)
-      preds <- pmin(preds, bounds[2])
+      preds <- do.call(cbind, lapply(seq(ncol(preds)), function(i){
+        bounds_y <- sort(bounds[[i]])
+        preds_y <- preds[,i,]
+        preds_y <- pmax(bounds_y[1], preds_y)
+        preds_y <- pmin(preds_y, bounds_y[2])
+        return(preds_y)
+      }))
     }
   }
 

--- a/R/summary.R
+++ b/R/summary.R
@@ -290,6 +290,7 @@ summary.hal9001 <- function(object,
     return_obj <- lapply(seq_along(copy_map), function(i){
       summarize_coefs(copy_map[[i]], coef_idxs[[i]], coefs_no_intercept[[i]], coefs[[i]])
     })
+    class(return_obj) <- "summary.hal9001"
   } else {
     return_obj <- summarize_coefs(copy_map, coef_idxs, coefs_no_intercept, coefs)
   }
@@ -305,7 +306,7 @@ summary.hal9001 <- function(object,
 #'
 #' @export
 print.summary.hal9001 <- function(x, length = NULL, ...) {
-  if(x$family != "mgaussian" || !is.null(x$family)) {
+  if(x$family != "mgaussian" && !is.null(x$family)) {
     if (x$only_nonzero_coefs & is.null(length)) {
       cat(
         "\n\nSummary of non-zero coefficients is based on lambda of",

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ predictions via Highly Adaptive Lasso regression:
 # load the package and set a seed
 library(hal9001)
 #> Loading required package: Rcpp
-#> hal9001 v0.4.3: The Scalable Highly Adaptive Lasso
+#> hal9001 v0.4.4: The Scalable Highly Adaptive Lasso
 #> note: fit_hal defaults have changed. See ?fit_hal for details
 set.seed(385971)
 
@@ -100,17 +100,17 @@ hal_fit <- fit_hal(X = x, Y = y, yolo = TRUE)
 #> [1] "I'm sorry, Dave. I'm afraid I can't do that."
 hal_fit$times
 #>                   user.self sys.self elapsed user.child sys.child
-#> enumerate_basis       0.007    0.000   0.007          0         0
-#> design_matrix         0.003    0.000   0.003          0         0
-#> reduce_basis          0.000    0.000   0.000          0         0
+#> enumerate_basis       0.012    0.003   0.020          0         0
+#> design_matrix         0.004    0.000   0.004          0         0
+#> reduce_basis          0.000    0.000   0.001          0         0
 #> remove_duplicates     0.000    0.000   0.000          0         0
-#> lasso                 1.499    0.024   1.529          0         0
-#> total                 1.509    0.024   1.539          0         0
+#> lasso                 2.660    0.272   4.215          0         0
+#> total                 2.677    0.276   4.240          0         0
 
 # training sample prediction
 preds <- predict(hal_fit, new_data = x)
 mean(hal_mse <- (preds - y)^2)
-#> [1] 0.03754093
+#> [1] 0.03667466
 ```
 
 ------------------------------------------------------------------------

--- a/README.md
+++ b/README.md
@@ -100,12 +100,12 @@ hal_fit <- fit_hal(X = x, Y = y, yolo = TRUE)
 #> [1] "I'm sorry, Dave. I'm afraid I can't do that."
 hal_fit$times
 #>                   user.self sys.self elapsed user.child sys.child
-#> enumerate_basis       0.012    0.003   0.020          0         0
-#> design_matrix         0.004    0.000   0.004          0         0
-#> reduce_basis          0.000    0.000   0.001          0         0
+#> enumerate_basis       0.014    0.003   0.059          0         0
+#> design_matrix         0.004    0.001   0.005          0         0
+#> reduce_basis          0.000    0.000   0.000          0         0
 #> remove_duplicates     0.000    0.000   0.000          0         0
-#> lasso                 2.660    0.272   4.215          0         0
-#> total                 2.677    0.276   4.240          0         0
+#> lasso                 2.684    0.343   6.583          0         0
+#> total                 2.703    0.348   6.655          0         0
 
 # training sample prediction
 preds <- predict(hal_fit, new_data = x)

--- a/docs/404.html
+++ b/docs/404.html
@@ -38,7 +38,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="https://tlverse.org/hal9001/index.html">hal9001</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.4.4</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.4.5</span>
       </span>
     </div>
 
@@ -95,14 +95,12 @@ Content not found. Please use links in the navbar.
 
       <footer><div class="copyright">
   <p></p>
-<p>Developed by Jeremy Coyle, Nima Hejazi, Rachael Phillips, Lars van
-der Laan, Mark van der Laan.</p>
+<p>Developed by Jeremy Coyle, Nima Hejazi, Rachael Phillips, Lars van der Laan, Mark van der Laan.</p>
 </div>
 
 <div class="pkgdown">
   <p></p>
-<p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a>
-2.0.2.</p>
+<p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.3.</p>
 </div>
 
       </footer>

--- a/docs/CONTRIBUTING.html
+++ b/docs/CONTRIBUTING.html
@@ -23,7 +23,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="index.html">hal9001</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.4.4</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.4.5</span>
       </span>
     </div>
 
@@ -60,92 +60,44 @@
 
 <div id="contributing-to-hal9001-development" class="section level1">
 
-<p>We, the authors of the <code>hal9001</code> R package, use the same
-guide as is used for contributing to the development of the popular
-<code>tidyverse</code> ecosystem of R packages. This document is simply
-a formal re-statement of that fact.</p>
-<p>The goal of this guide is to help you get up and contributing to
-<code>hal9001</code> as quickly as possible. The guide is divided into
-two main pieces:</p>
+<p>We, the authors of the <code>hal9001</code> R package, use the same guide as is used for contributing to the development of the popular <code>tidyverse</code> ecosystem of R packages. This document is simply a formal re-statement of that fact.</p>
+<p>The goal of this guide is to help you get up and contributing to <code>hal9001</code> as quickly as possible. The guide is divided into two main pieces:</p>
 <ul><li>Filing a bug report or feature request in an issue.</li>
 <li>Suggesting a change via a pull request.</li>
 </ul><div class="section level2">
 <h2 id="issues">Issues<a class="anchor" aria-label="anchor" href="#issues"></a></h2>
-<p>When filing an issue, the most important thing is to include a
-minimal reproducible example so that we can quickly verify the problem,
-and then figure out how to fix it. There are three things you need to
-include to make your example reproducible: required packages, data,
-code.</p>
-<ol style="list-style-type: decimal"><li><p><strong>Packages</strong> should be loaded at the top of the
-script, so it’s easy to see which ones the example needs.</p></li>
-<li><p>The easiest way to include <strong>data</strong> is to use
-<code><a href="https://rdrr.io/r/base/dput.html" class="external-link">dput()</a></code> to generate the R code to recreate it.</p></li>
+<p>When filing an issue, the most important thing is to include a minimal reproducible example so that we can quickly verify the problem, and then figure out how to fix it. There are three things you need to include to make your example reproducible: required packages, data, code.</p>
+<ol style="list-style-type: decimal"><li><p><strong>Packages</strong> should be loaded at the top of the script, so it’s easy to see which ones the example needs.</p></li>
+<li><p>The easiest way to include <strong>data</strong> is to use <code><a href="https://rdrr.io/r/base/dput.html" class="external-link">dput()</a></code> to generate the R code to recreate it.</p></li>
 <li>
-<p>Spend a little bit of time ensuring that your
-<strong>code</strong> is easy for others to read:</p>
-<ul><li><p>make sure you’ve used spaces and your variable names are concise,
-but informative</p></li>
+<p>Spend a little bit of time ensuring that your <strong>code</strong> is easy for others to read:</p>
+<ul><li><p>make sure you’ve used spaces and your variable names are concise, but informative</p></li>
 <li><p>use comments to indicate where your problem lies</p></li>
-<li><p>do your best to remove everything that is not related to the
-problem. The shorter your code is, the easier it is to
-understand.</p></li>
+<li><p>do your best to remove everything that is not related to the problem. The shorter your code is, the easier it is to understand.</p></li>
 </ul></li>
-</ol><p>You can check you have actually made a reproducible example by
-starting up a fresh R session and pasting your script in.</p>
-<p>(Unless you’ve been specifically asked for it, please don’t include
-the output of <code><a href="https://rdrr.io/r/utils/sessionInfo.html" class="external-link">sessionInfo()</a></code>.)</p>
+</ol><p>You can check you have actually made a reproducible example by starting up a fresh R session and pasting your script in.</p>
+<p>(Unless you’ve been specifically asked for it, please don’t include the output of <code><a href="https://rdrr.io/r/utils/sessionInfo.html" class="external-link">sessionInfo()</a></code>.)</p>
 </div>
 <div class="section level2">
 <h2 id="pull-requests">Pull requests<a class="anchor" aria-label="anchor" href="#pull-requests"></a></h2>
-<p>To contribute a change to <code>hal9001</code>, you follow these
-steps:</p>
+<p>To contribute a change to <code>hal9001</code>, you follow these steps:</p>
 <ol style="list-style-type: decimal"><li>Create a branch in git and make your changes.</li>
 <li>Push branch to GitHub and issue pull request (PR).</li>
 <li>Discuss the pull request.</li>
-<li>Iterate until either we accept the PR or decide that it’s not a good
-fit for <code>hal9001</code>.</li>
-</ol><p>Each of these steps are described in more detail below. This might
-feel overwhelming the first time you get set up, but it gets easier with
-practice.</p>
+<li>Iterate until either we accept the PR or decide that it’s not a good fit for <code>hal9001</code>.</li>
+</ol><p>Each of these steps are described in more detail below. This might feel overwhelming the first time you get set up, but it gets easier with practice.</p>
 <p>If you’re not familiar with git or GitHub, please start by reading <a href="http://r-pkgs.had.co.nz/git.html" class="external-link uri">http://r-pkgs.had.co.nz/git.html</a></p>
 <p>Pull requests will be evaluated against a checklist:</p>
 <ol style="list-style-type: decimal"><li>
-<strong>Motivation</strong>. Your pull request should clearly and
-concisely motivates the need for change. Please describe the problem
-your PR addresses and show how your pull request solves it as concisely
-as possible.</li>
-</ol><p>Also include this motivation in <code>NEWS</code> so that when a new
-release of <code>hal9001</code> comes out it’s easy for users to see
-what’s changed. Add your item at the top of the file and use markdown
-for formatting. The news item should end with
-<code>(@yourGithubUsername, #the_issue_number)</code>.</p>
+<strong>Motivation</strong>. Your pull request should clearly and concisely motivates the need for change. Please describe the problem your PR addresses and show how your pull request solves it as concisely as possible.</li>
+</ol><p>Also include this motivation in <code>NEWS</code> so that when a new release of <code>hal9001</code> comes out it’s easy for users to see what’s changed. Add your item at the top of the file and use markdown for formatting. The news item should end with <code>(@yourGithubUsername, #the_issue_number)</code>.</p>
 <ol start="2" style="list-style-type: decimal"><li>
-<p><strong>Only related changes</strong>. Before you submit your
-pull request, please check to make sure that you haven’t accidentally
-included any unrelated changes. These make it harder to see exactly
-what’s changed, and to evaluate any unexpected side effects.</p>
-<p>Each PR corresponds to a git branch, so if you expect to submit
-multiple changes make sure to create multiple branches. If you have
-multiple changes that depend on each other, start with the first one and
-don’t submit any others until the first one has been processed.</p>
+<p><strong>Only related changes</strong>. Before you submit your pull request, please check to make sure that you haven’t accidentally included any unrelated changes. These make it harder to see exactly what’s changed, and to evaluate any unexpected side effects.</p>
+<p>Each PR corresponds to a git branch, so if you expect to submit multiple changes make sure to create multiple branches. If you have multiple changes that depend on each other, start with the first one and don’t submit any others until the first one has been processed.</p>
 </li>
-<li><p><strong>Use <code>hal9001</code> coding style</strong>. To do so,
-please follow the <a href="http://style.tidyverse.org" class="external-link">official
-<code>tidyverse</code> style guide</a>. Maintaining a consistent style
-across the whole code base makes it much easier to jump into the code.
-If you’re modifying existing <code>hal9001</code> code that doesn’t
-follow the style guide, a separate pull request to fix the style would
-be greatly appreciated.</p></li>
-<li><p>If you’re adding new parameters or a new function, you’ll also
-need to document them with <a href="https://github.com/klutometis/roxygen" class="external-link"><code>roxygen2</code></a>.
-Make sure to re-run <code><a href="https://devtools.r-lib.org/reference/document.html" class="external-link">devtools::document()</a></code> on the code before
-submitting.</p></li>
-</ol><p>This seems like a lot of work but don’t worry if your pull request
-isn’t perfect. It’s a learning process. A pull request is a process, and
-unless you’ve submitted a few in the past it’s unlikely that your pull
-request will be accepted as is. Please don’t submit pull requests that
-change existing behaviour. Instead, think about how you can add a new
-feature in a minimally invasive way.</p>
+<li><p><strong>Use <code>hal9001</code> coding style</strong>. To do so, please follow the <a href="http://style.tidyverse.org" class="external-link">official <code>tidyverse</code> style guide</a>. Maintaining a consistent style across the whole code base makes it much easier to jump into the code. If you’re modifying existing <code>hal9001</code> code that doesn’t follow the style guide, a separate pull request to fix the style would be greatly appreciated.</p></li>
+<li><p>If you’re adding new parameters or a new function, you’ll also need to document them with <a href="https://github.com/klutometis/roxygen" class="external-link"><code>roxygen2</code></a>. Make sure to re-run <code><a href="https://devtools.r-lib.org/reference/document.html" class="external-link">devtools::document()</a></code> on the code before submitting.</p></li>
+</ol><p>This seems like a lot of work but don’t worry if your pull request isn’t perfect. It’s a learning process. A pull request is a process, and unless you’ve submitted a few in the past it’s unlikely that your pull request will be accepted as is. Please don’t submit pull requests that change existing behaviour. Instead, think about how you can add a new feature in a minimally invasive way.</p>
 </div>
 </div>
 
@@ -160,13 +112,11 @@ feature in a minimally invasive way.</p>
 
 
       <footer><div class="copyright">
-  <p></p><p>Developed by Jeremy Coyle, Nima Hejazi, Rachael Phillips, Lars van
-der Laan, Mark van der Laan.</p>
+  <p></p><p>Developed by Jeremy Coyle, Nima Hejazi, Rachael Phillips, Lars van der Laan, Mark van der Laan.</p>
 </div>
 
 <div class="pkgdown">
-  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a>
-2.0.2.</p>
+  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.3.</p>
 </div>
 
       </footer></div>

--- a/docs/LICENSE-text.html
+++ b/docs/LICENSE-text.html
@@ -23,7 +23,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="index.html">hal9001</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.4.4</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.4.5</span>
       </span>
     </div>
 
@@ -746,13 +746,11 @@ Public License instead of this License.  But first, please read
 
 
       <footer><div class="copyright">
-  <p></p><p>Developed by Jeremy Coyle, Nima Hejazi, Rachael Phillips, Lars van
-der Laan, Mark van der Laan.</p>
+  <p></p><p>Developed by Jeremy Coyle, Nima Hejazi, Rachael Phillips, Lars van der Laan, Mark van der Laan.</p>
 </div>
 
 <div class="pkgdown">
-  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a>
-2.0.2.</p>
+  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.3.</p>
 </div>
 
       </footer></div>

--- a/docs/articles/index.html
+++ b/docs/articles/index.html
@@ -23,7 +23,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">hal9001</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.4.4</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.4.5</span>
       </span>
     </div>
 
@@ -70,13 +70,11 @@
 
 
       <footer><div class="copyright">
-  <p></p><p>Developed by Jeremy Coyle, Nima Hejazi, Rachael Phillips, Lars van
-der Laan, Mark van der Laan.</p>
+  <p></p><p>Developed by Jeremy Coyle, Nima Hejazi, Rachael Phillips, Lars van der Laan, Mark van der Laan.</p>
 </div>
 
 <div class="pkgdown">
-  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a>
-2.0.2.</p>
+  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.3.</p>
 </div>
 
       </footer></div>

--- a/docs/articles/intro_hal9001.html
+++ b/docs/articles/intro_hal9001.html
@@ -165,12 +165,12 @@ step:</p>
 <code class="sourceCode R"><span class="va">hal_fit</span> <span class="op">&lt;-</span> <span class="fu"><a href="../reference/fit_hal.html">fit_hal</a></span><span class="op">(</span>X <span class="op">=</span> <span class="va">x</span>, Y <span class="op">=</span> <span class="va">y</span><span class="op">)</span>
 <span class="va">hal_fit</span><span class="op">$</span><span class="va">times</span></code></pre></div>
 <pre><code><span class="co">##                   user.self sys.self elapsed user.child sys.child</span>
-<span class="co">## enumerate_basis       0.026    0.003   0.037          0         0</span>
-<span class="co">## design_matrix         0.125    0.009   0.179          0         0</span>
+<span class="co">## enumerate_basis       0.027    0.003   0.053          0         0</span>
+<span class="co">## design_matrix         0.129    0.021   0.340          0         0</span>
 <span class="co">## reduce_basis          0.000    0.000   0.000          0         0</span>
 <span class="co">## remove_duplicates     0.000    0.000   0.000          0         0</span>
-<span class="co">## lasso                 3.433    0.370   5.456          0         0</span>
-<span class="co">## total                 3.585    0.382   5.673          0         0</span></code></pre>
+<span class="co">## lasso                 3.577    0.436   9.466          0         0</span>
+<span class="co">## total                 3.734    0.460   9.861          0         0</span></code></pre>
 </div>
 <div class="section level3">
 <h3 id="summarizing-the-model">Summarizing the model<a class="anchor" aria-label="anchor" href="#summarizing-the-model"></a>
@@ -345,12 +345,12 @@ function:</p>
 <div class="sourceCode" id="cb19"><pre class="downlit sourceCode r">
 <code class="sourceCode R"><span class="va">hal_fit_reduced</span><span class="op">$</span><span class="va">times</span></code></pre></div>
 <pre><code><span class="co">##                   user.self sys.self elapsed user.child sys.child</span>
-<span class="co">## enumerate_basis       0.023    0.004   0.034          0         0</span>
-<span class="co">## design_matrix         0.122    0.013   0.200          0         0</span>
+<span class="co">## enumerate_basis       0.028    0.007   0.122          0         0</span>
+<span class="co">## design_matrix         0.131    0.017   0.463          0         0</span>
 <span class="co">## reduce_basis          0.000    0.000   0.000          0         0</span>
 <span class="co">## remove_duplicates     0.000    0.000   0.000          0         0</span>
-<span class="co">## lasso                 3.377    0.399   5.419          0         0</span>
-<span class="co">## total                 3.522    0.416   5.653          0         0</span></code></pre>
+<span class="co">## lasso                 3.667    0.733  16.867          0         0</span>
+<span class="co">## total                 3.826    0.757  17.453          0         0</span></code></pre>
 <p>In the above, all basis functions with fewer than 10% of observations
 meeting the criterion imposed are automatically removed prior to the
 Lasso step of fitting the HAL regression. The results appear below</p>

--- a/docs/articles/intro_hal9001.html
+++ b/docs/articles/intro_hal9001.html
@@ -39,7 +39,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">hal9001</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.4.4</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.4.5</span>
       </span>
     </div>
 
@@ -85,7 +85,7 @@
 <a href="https://nimahejazi.org" class="external-link">Nima Hejazi</a>, <a href="https://github.com/jeremyrcoyle" class="external-link">Jeremy Coyle</a>, Rachael
 Phillips, Lars van der Laan</h4>
             
-            <h4 data-toc-skip class="date">2022-03-29</h4>
+            <h4 data-toc-skip class="date">2022-07-12</h4>
       
       <small class="dont-index">Source: <a href="https://github.com/tlverse/hal9001/blob/HEAD/vignettes/intro_hal9001.Rmd" class="external-link"><code>vignettes/intro_hal9001.Rmd</code></a></small>
       <div class="hidden name"><code>intro_hal9001.Rmd</code></div>
@@ -154,7 +154,7 @@ descriptions of HAL and its various optimality properties.</p>
 <div class="sourceCode" id="cb6"><pre class="downlit sourceCode r">
 <code class="sourceCode R"><span class="kw"><a href="https://rdrr.io/r/base/library.html" class="external-link">library</a></span><span class="op">(</span><span class="va"><a href="https://github.com/tlverse/hal9001" class="external-link">hal9001</a></span><span class="op">)</span></code></pre></div>
 <pre><code><span class="co">## Loading required package: Rcpp</span></code></pre>
-<pre><code><span class="co">## hal9001 v0.4.4: The Scalable Highly Adaptive Lasso</span>
+<pre><code><span class="co">## hal9001 v0.4.5: The Scalable Highly Adaptive Lasso</span>
 <span class="co">## note: fit_hal defaults have changed. See ?fit_hal for details</span></code></pre>
 <div class="section level3">
 <h3 id="fitting-the-model">Fitting the model<a class="anchor" aria-label="anchor" href="#fitting-the-model"></a>
@@ -165,12 +165,12 @@ step:</p>
 <code class="sourceCode R"><span class="va">hal_fit</span> <span class="op">&lt;-</span> <span class="fu"><a href="../reference/fit_hal.html">fit_hal</a></span><span class="op">(</span>X <span class="op">=</span> <span class="va">x</span>, Y <span class="op">=</span> <span class="va">y</span><span class="op">)</span>
 <span class="va">hal_fit</span><span class="op">$</span><span class="va">times</span></code></pre></div>
 <pre><code><span class="co">##                   user.self sys.self elapsed user.child sys.child</span>
-<span class="co">## enumerate_basis       0.015    0.000   0.015          0         0</span>
-<span class="co">## design_matrix         0.084    0.002   0.086          0         0</span>
+<span class="co">## enumerate_basis       0.026    0.003   0.037          0         0</span>
+<span class="co">## design_matrix         0.125    0.009   0.179          0         0</span>
 <span class="co">## reduce_basis          0.000    0.000   0.000          0         0</span>
 <span class="co">## remove_duplicates     0.000    0.000   0.000          0         0</span>
-<span class="co">## lasso                 2.283    0.093   2.524          0         0</span>
-<span class="co">## total                 2.382    0.095   2.626          0         0</span></code></pre>
+<span class="co">## lasso                 3.433    0.370   5.456          0         0</span>
+<span class="co">## total                 3.585    0.382   5.673          0         0</span></code></pre>
 </div>
 <div class="section level3">
 <h3 id="summarizing-the-model">Summarizing the model<a class="anchor" aria-label="anchor" href="#summarizing-the-model"></a>
@@ -339,19 +339,22 @@ default.</p>
 <code>reduce_basis</code> argument to the <code>fit_hal</code>
 function:</p>
 <div class="sourceCode" id="cb17"><pre class="downlit sourceCode r">
-<code class="sourceCode R"><span class="va">hal_fit_reduced</span> <span class="op">&lt;-</span> <span class="fu"><a href="../reference/fit_hal.html">fit_hal</a></span><span class="op">(</span>X <span class="op">=</span> <span class="va">x</span>, Y <span class="op">=</span> <span class="va">y</span>, reduce_basis <span class="op">=</span> <span class="fl">0.1</span><span class="op">)</span>
-<span class="va">hal_fit_reduced</span><span class="op">$</span><span class="va">times</span></code></pre></div>
+<code class="sourceCode R"><span class="va">hal_fit_reduced</span> <span class="op">&lt;-</span> <span class="fu"><a href="../reference/fit_hal.html">fit_hal</a></span><span class="op">(</span>X <span class="op">=</span> <span class="va">x</span>, Y <span class="op">=</span> <span class="va">y</span>, reduce_basis <span class="op">=</span> <span class="fl">0.1</span><span class="op">)</span></code></pre></div>
+<pre><code><span class="co">## Warning in fit_hal(X = x, Y = y, reduce_basis = 0.1): Dropping reduce_basis;</span>
+<span class="co">## only applies if smoothness_orders = 0</span></code></pre>
+<div class="sourceCode" id="cb19"><pre class="downlit sourceCode r">
+<code class="sourceCode R"><span class="va">hal_fit_reduced</span><span class="op">$</span><span class="va">times</span></code></pre></div>
 <pre><code><span class="co">##                   user.self sys.self elapsed user.child sys.child</span>
-<span class="co">## enumerate_basis       0.013    0.001   0.014          0         0</span>
-<span class="co">## design_matrix         0.078    0.002   0.080          0         0</span>
+<span class="co">## enumerate_basis       0.023    0.004   0.034          0         0</span>
+<span class="co">## design_matrix         0.122    0.013   0.200          0         0</span>
 <span class="co">## reduce_basis          0.000    0.000   0.000          0         0</span>
 <span class="co">## remove_duplicates     0.000    0.000   0.000          0         0</span>
-<span class="co">## lasso                 2.063    0.079   2.231          0         0</span>
-<span class="co">## total                 2.154    0.082   2.325          0         0</span></code></pre>
+<span class="co">## lasso                 3.377    0.399   5.419          0         0</span>
+<span class="co">## total                 3.522    0.416   5.653          0         0</span></code></pre>
 <p>In the above, all basis functions with fewer than 10% of observations
 meeting the criterion imposed are automatically removed prior to the
 Lasso step of fitting the HAL regression. The results appear below</p>
-<div class="sourceCode" id="cb19"><pre class="downlit sourceCode r">
+<div class="sourceCode" id="cb21"><pre class="downlit sourceCode r">
 <code class="sourceCode R"><span class="fu"><a href="https://rdrr.io/r/base/summary.html" class="external-link">summary</a></span><span class="op">(</span><span class="va">hal_fit_reduced</span><span class="op">)</span><span class="op">$</span><span class="va">table</span></code></pre></div>
 <pre><code><span class="co">##              coef</span>
 <span class="co">##  1: -1.424003e+00</span>
@@ -464,7 +467,7 @@ corresponds to a piece-wise polynomial fit of degree <span class="math inline">\
 under the constraint that the total variation of the function’s <span class="math inline">\(k^{\text{th}}\)</span> derivative is bounded by
 some constant, which is selected with cross-validation.</p>
 <p>Let’s see this in action.</p>
-<div class="sourceCode" id="cb21"><pre class="downlit sourceCode r">
+<div class="sourceCode" id="cb23"><pre class="downlit sourceCode r">
 <code class="sourceCode R"><span class="fu"><a href="https://rdrr.io/r/base/Random.html" class="external-link">set.seed</a></span><span class="op">(</span><span class="fl">98109</span><span class="op">)</span>
 <span class="va">num_knots</span> <span class="op">&lt;-</span> <span class="fl">100</span> <span class="co"># Try changing this value to see what happens.</span>
 <span class="va">n_covars</span> <span class="op">&lt;-</span> <span class="fl">1</span>
@@ -510,16 +513,16 @@ imposing higher-order smoothness is that fewer knot points are required
 for a near-optimal fit. Therefore, one can safely pass a smaller value
 to <code>num_knots</code> for a big decrease in runtime without
 sacrificing performance.</p>
-<div class="sourceCode" id="cb22"><pre class="downlit sourceCode r">
+<div class="sourceCode" id="cb24"><pre class="downlit sourceCode r">
 <code class="sourceCode R"><span class="fu"><a href="https://rdrr.io/r/base/mean.html" class="external-link">mean</a></span><span class="op">(</span><span class="op">(</span><span class="va">pred_0</span> <span class="op">-</span> <span class="va">ytrue</span><span class="op">)</span><span class="op">^</span><span class="fl">2</span><span class="op">)</span></code></pre></div>
 <pre><code><span class="co">## [1] 0.00732315</span></code></pre>
-<div class="sourceCode" id="cb24"><pre class="downlit sourceCode r">
+<div class="sourceCode" id="cb26"><pre class="downlit sourceCode r">
 <code class="sourceCode R"><span class="fu"><a href="https://rdrr.io/r/base/mean.html" class="external-link">mean</a></span><span class="op">(</span><span class="op">(</span><span class="va">pred_smooth_1</span><span class="op">-</span> <span class="va">ytrue</span><span class="op">)</span><span class="op">^</span><span class="fl">2</span><span class="op">)</span></code></pre></div>
 <pre><code><span class="co">## [1] 0.003458005</span></code></pre>
-<div class="sourceCode" id="cb26"><pre class="downlit sourceCode r">
+<div class="sourceCode" id="cb28"><pre class="downlit sourceCode r">
 <code class="sourceCode R"><span class="fu"><a href="https://rdrr.io/r/base/mean.html" class="external-link">mean</a></span><span class="op">(</span><span class="op">(</span><span class="va">pred_smooth_2</span> <span class="op">-</span> <span class="va">ytrue</span><span class="op">)</span><span class="op">^</span><span class="fl">2</span><span class="op">)</span></code></pre></div>
 <pre><code><span class="co">## [1] 0.001834611</span></code></pre>
-<div class="sourceCode" id="cb28"><pre class="downlit sourceCode r">
+<div class="sourceCode" id="cb30"><pre class="downlit sourceCode r">
 <code class="sourceCode R"><span class="va">dt</span> <span class="op">&lt;-</span> <span class="fu"><a href="https://Rdatatable.gitlab.io/data.table/reference/data.table.html" class="external-link">data.table</a></span><span class="op">(</span>x <span class="op">=</span> <span class="fu"><a href="https://rdrr.io/r/base/vector.html" class="external-link">as.vector</a></span><span class="op">(</span><span class="va">x</span><span class="op">)</span>,
                  ytrue <span class="op">=</span> <span class="va">ytrue</span>,
                  y <span class="op">=</span> <span class="va">y</span>,
@@ -529,13 +532,13 @@ sacrificing performance.</p>
 <span class="va">long</span> <span class="op">&lt;-</span> <span class="fu"><a href="https://Rdatatable.gitlab.io/data.table/reference/melt.data.table.html" class="external-link">melt</a></span><span class="op">(</span><span class="va">dt</span>, id <span class="op">=</span> <span class="st">"x"</span><span class="op">)</span>
 <span class="fu"><a href="https://ggplot2.tidyverse.org/reference/ggplot.html" class="external-link">ggplot</a></span><span class="op">(</span><span class="va">long</span>, <span class="fu"><a href="https://ggplot2.tidyverse.org/reference/aes.html" class="external-link">aes</a></span><span class="op">(</span>x <span class="op">=</span> <span class="va">x</span>, y <span class="op">=</span> <span class="va">value</span>, color <span class="op">=</span> <span class="va">variable</span><span class="op">)</span><span class="op">)</span> <span class="op">+</span> <span class="fu"><a href="https://ggplot2.tidyverse.org/reference/geom_path.html" class="external-link">geom_line</a></span><span class="op">(</span><span class="op">)</span></code></pre></div>
 <p><img src="intro_hal9001_files/figure-html/unnamed-chunk-3-1.png" width="700"></p>
-<div class="sourceCode" id="cb29"><pre class="downlit sourceCode r">
+<div class="sourceCode" id="cb31"><pre class="downlit sourceCode r">
 <code class="sourceCode R"><span class="fu"><a href="https://rdrr.io/r/graphics/plot.default.html" class="external-link">plot</a></span><span class="op">(</span><span class="va">x</span>, <span class="va">pred_0</span>, main <span class="op">=</span> <span class="st">"Zero order smoothness fit"</span><span class="op">)</span></code></pre></div>
 <p><img src="intro_hal9001_files/figure-html/unnamed-chunk-3-2.png" width="700"></p>
-<div class="sourceCode" id="cb30"><pre class="downlit sourceCode r">
+<div class="sourceCode" id="cb32"><pre class="downlit sourceCode r">
 <code class="sourceCode R"><span class="fu"><a href="https://rdrr.io/r/graphics/plot.default.html" class="external-link">plot</a></span><span class="op">(</span><span class="va">x</span>, <span class="va">pred_smooth_1</span>, main <span class="op">=</span> <span class="st">"First order smoothness fit"</span><span class="op">)</span></code></pre></div>
 <p><img src="intro_hal9001_files/figure-html/unnamed-chunk-3-3.png" width="700"></p>
-<div class="sourceCode" id="cb31"><pre class="downlit sourceCode r">
+<div class="sourceCode" id="cb33"><pre class="downlit sourceCode r">
 <code class="sourceCode R"><span class="fu"><a href="https://rdrr.io/r/graphics/plot.default.html" class="external-link">plot</a></span><span class="op">(</span><span class="va">x</span>, <span class="va">pred_smooth_2</span>, main <span class="op">=</span> <span class="st">"Second order smoothness fit"</span><span class="op">)</span></code></pre></div>
 <p><img src="intro_hal9001_files/figure-html/unnamed-chunk-3-4.png" width="700"></p>
 <p>In general, if the basis functions are not coarse, then the
@@ -549,7 +552,7 @@ data-adaptively choose the optimal smoothness (invoked in
 Comparing the following simulation and the previous one, the HAL with
 second-order smoothness performed better when there were fewer knot
 points.</p>
-<div class="sourceCode" id="cb32"><pre class="downlit sourceCode r">
+<div class="sourceCode" id="cb34"><pre class="downlit sourceCode r">
 <code class="sourceCode R"><span class="fu"><a href="https://rdrr.io/r/base/Random.html" class="external-link">set.seed</a></span><span class="op">(</span><span class="fl">98109</span><span class="op">)</span>
 <span class="va">n_covars</span> <span class="op">&lt;-</span> <span class="fl">1</span>
 <span class="va">n_obs</span> <span class="op">&lt;-</span> <span class="fl">250</span>
@@ -571,22 +574,22 @@ points.</p>
 <span class="va">pred_0</span> <span class="op">&lt;-</span> <span class="fu"><a href="https://rdrr.io/r/stats/predict.html" class="external-link">predict</a></span><span class="op">(</span><span class="va">hal_fit_0</span>, new_data <span class="op">=</span> <span class="va">x</span><span class="op">)</span>
 <span class="va">pred_smooth_1</span> <span class="op">&lt;-</span> <span class="fu"><a href="https://rdrr.io/r/stats/predict.html" class="external-link">predict</a></span><span class="op">(</span><span class="va">hal_fit_smooth_1</span>, new_data <span class="op">=</span> <span class="va">x</span><span class="op">)</span>
 <span class="va">pred_smooth_2</span> <span class="op">&lt;-</span> <span class="fu"><a href="https://rdrr.io/r/stats/predict.html" class="external-link">predict</a></span><span class="op">(</span><span class="va">hal_fit_smooth_2</span>, new_data <span class="op">=</span> <span class="va">x</span><span class="op">)</span></code></pre></div>
-<div class="sourceCode" id="cb33"><pre class="downlit sourceCode r">
+<div class="sourceCode" id="cb35"><pre class="downlit sourceCode r">
 <code class="sourceCode R"><span class="fu"><a href="https://rdrr.io/r/base/mean.html" class="external-link">mean</a></span><span class="op">(</span><span class="op">(</span><span class="va">pred_0</span> <span class="op">-</span> <span class="va">ytrue</span><span class="op">)</span><span class="op">^</span><span class="fl">2</span><span class="op">)</span></code></pre></div>
 <pre><code><span class="co">## [1] 0.00732315</span></code></pre>
-<div class="sourceCode" id="cb35"><pre class="downlit sourceCode r">
+<div class="sourceCode" id="cb37"><pre class="downlit sourceCode r">
 <code class="sourceCode R"><span class="fu"><a href="https://rdrr.io/r/base/mean.html" class="external-link">mean</a></span><span class="op">(</span><span class="op">(</span><span class="va">pred_smooth_1</span><span class="op">-</span> <span class="va">ytrue</span><span class="op">)</span><span class="op">^</span><span class="fl">2</span><span class="op">)</span></code></pre></div>
 <pre><code><span class="co">## [1] 0.003458005</span></code></pre>
-<div class="sourceCode" id="cb37"><pre class="downlit sourceCode r">
+<div class="sourceCode" id="cb39"><pre class="downlit sourceCode r">
 <code class="sourceCode R"><span class="fu"><a href="https://rdrr.io/r/base/mean.html" class="external-link">mean</a></span><span class="op">(</span><span class="op">(</span><span class="va">pred_smooth_2</span> <span class="op">-</span> <span class="va">ytrue</span><span class="op">)</span><span class="op">^</span><span class="fl">2</span><span class="op">)</span></code></pre></div>
 <pre><code><span class="co">## [1] 0.001848927</span></code></pre>
-<div class="sourceCode" id="cb39"><pre class="downlit sourceCode r">
+<div class="sourceCode" id="cb41"><pre class="downlit sourceCode r">
 <code class="sourceCode R"><span class="fu"><a href="https://rdrr.io/r/graphics/plot.default.html" class="external-link">plot</a></span><span class="op">(</span><span class="va">x</span>, <span class="va">pred_0</span>, main <span class="op">=</span> <span class="st">"Zero order smoothness fit"</span><span class="op">)</span></code></pre></div>
 <p><img src="intro_hal9001_files/figure-html/unnamed-chunk-5-1.png" width="700"></p>
-<div class="sourceCode" id="cb40"><pre class="downlit sourceCode r">
+<div class="sourceCode" id="cb42"><pre class="downlit sourceCode r">
 <code class="sourceCode R"><span class="fu"><a href="https://rdrr.io/r/graphics/plot.default.html" class="external-link">plot</a></span><span class="op">(</span><span class="va">x</span>, <span class="va">pred_smooth_1</span>, main <span class="op">=</span> <span class="st">"First order smoothness fit"</span><span class="op">)</span></code></pre></div>
 <p><img src="intro_hal9001_files/figure-html/unnamed-chunk-5-2.png" width="700"></p>
-<div class="sourceCode" id="cb41"><pre class="downlit sourceCode r">
+<div class="sourceCode" id="cb43"><pre class="downlit sourceCode r">
 <code class="sourceCode R"><span class="fu"><a href="https://rdrr.io/r/graphics/plot.default.html" class="external-link">plot</a></span><span class="op">(</span><span class="va">x</span>, <span class="va">pred_smooth_2</span>, main <span class="op">=</span> <span class="st">"Second order smoothness fit"</span><span class="op">)</span></code></pre></div>
 <p><img src="intro_hal9001_files/figure-html/unnamed-chunk-5-3.png" width="700"></p>
 </div>
@@ -606,7 +609,7 @@ information for <code>fit_hal</code> and <code>glmnet</code>. The
 <code>fit_hal</code>, and the user-supplied character string is inputted
 into <code>fit_hal</code>. Here, we call <code>formula_hal</code>
 directly for illustrative purposes.</p>
-<div class="sourceCode" id="cb42"><pre class="downlit sourceCode r">
+<div class="sourceCode" id="cb44"><pre class="downlit sourceCode r">
 <code class="sourceCode R"><span class="fu"><a href="https://rdrr.io/r/base/Random.html" class="external-link">set.seed</a></span><span class="op">(</span><span class="fl">98109</span><span class="op">)</span>
 <span class="va">num_knots</span> <span class="op">&lt;-</span> <span class="fl">100</span>
 
@@ -624,7 +627,7 @@ ignored in <code>formula_hal</code>). This is why
 <code>formula_hal</code> takes the input <code>X</code> matrix of
 covariates, and not <code>X</code> and <code>Y</code>. In what follows,
 we include formulas with and without “y” in the character string.</p>
-<div class="sourceCode" id="cb43"><pre class="downlit sourceCode r">
+<div class="sourceCode" id="cb45"><pre class="downlit sourceCode r">
 <code class="sourceCode R"><span class="co"># The `h` function is used to specify the basis functions for a given term</span>
 <span class="co"># h(x1) generates one-way basis functions for the variable x1</span>
 <span class="co"># This is an additive model:</span>
@@ -643,7 +646,7 @@ we include formulas with and without “y” in the character string.</p>
 <span class="co">## </span>
 <span class="co">## $orders</span>
 <span class="co">## [1] 0</span></code></pre>
-<div class="sourceCode" id="cb45"><pre class="downlit sourceCode r">
+<div class="sourceCode" id="cb47"><pre class="downlit sourceCode r">
 <code class="sourceCode R"><span class="co"># We don't need the variables in the parent environment if we specify them directly:</span>
 <span class="fu"><a href="https://rdrr.io/r/base/rm.html" class="external-link">rm</a></span><span class="op">(</span><span class="va">smoothness_orders</span><span class="op">)</span>
 <span class="fu"><a href="https://rdrr.io/r/base/rm.html" class="external-link">rm</a></span><span class="op">(</span><span class="va">num_knots</span><span class="op">)</span>
@@ -652,7 +655,7 @@ we include formulas with and without “y” in the character string.</p>
 <span class="co"># They are the same!</span>
 <span class="fu"><a href="https://rdrr.io/r/base/length.html" class="external-link">length</a></span><span class="op">(</span> <span class="va">form_term_new</span><span class="op">$</span><span class="va">basis_list</span><span class="op">)</span> <span class="op">==</span> <span class="fu"><a href="https://rdrr.io/r/base/length.html" class="external-link">length</a></span><span class="op">(</span><span class="va">form_term</span><span class="op">$</span><span class="va">basis_list</span><span class="op">)</span></code></pre></div>
 <pre><code><span class="co">## [1] TRUE</span></code></pre>
-<div class="sourceCode" id="cb47"><pre class="downlit sourceCode r">
+<div class="sourceCode" id="cb49"><pre class="downlit sourceCode r">
 <code class="sourceCode R"><span class="co">#To evaluate a unevaluated formula object like:</span>
 <span class="va">formula</span> <span class="op">&lt;-</span> <span class="op">~</span><span class="fu"><a href="../reference/h.html">h</a></span><span class="op">(</span><span class="va">x1</span><span class="op">)</span> <span class="op">+</span> <span class="fu"><a href="../reference/h.html">h</a></span><span class="op">(</span><span class="va">x2</span><span class="op">)</span> <span class="op">+</span> <span class="fu"><a href="../reference/h.html">h</a></span><span class="op">(</span><span class="va">A</span><span class="op">)</span>
 <span class="co"># we can use the formula_hal function:</span>
@@ -669,13 +672,13 @@ all or a subset of variables using the <code>.</code> variable and
 <code>h(.)</code> is treated as a wildcard and basis functions are
 generated by replacing the <code>.</code> with all variables in
 <code>X</code>.</p>
-<div class="sourceCode" id="cb48"><pre class="downlit sourceCode r">
+<div class="sourceCode" id="cb50"><pre class="downlit sourceCode r">
 <code class="sourceCode R"><span class="va">smoothness_orders</span> <span class="op">&lt;-</span> <span class="fl">1</span>
 <span class="va">num_knots</span> <span class="op">&lt;-</span> <span class="fl">5</span>
 <span class="co"># A additive model</span>
 <span class="fu"><a href="https://rdrr.io/r/base/colnames.html" class="external-link">colnames</a></span><span class="op">(</span><span class="va">X</span><span class="op">)</span></code></pre></div>
 <pre><code><span class="co">## [1] "x1" "x2" "A"</span></code></pre>
-<div class="sourceCode" id="cb50"><pre class="downlit sourceCode r">
+<div class="sourceCode" id="cb52"><pre class="downlit sourceCode r">
 <code class="sourceCode R"><span class="co"># Shortcut:</span>
 <span class="va">formula1</span> <span class="op">&lt;-</span> <span class="fu"><a href="../reference/h.html">h</a></span><span class="op">(</span><span class="va">.</span><span class="op">)</span>
 <span class="co"># Longcut:</span>
@@ -683,7 +686,7 @@ generated by replacing the <code>.</code> with all variables in
 <span class="co"># Same number of basis functions</span>
 <span class="fu"><a href="https://rdrr.io/r/base/length.html" class="external-link">length</a></span><span class="op">(</span><span class="va">formula1</span><span class="op">$</span><span class="va">basis_list</span> <span class="op">)</span> <span class="op">==</span> <span class="fu"><a href="https://rdrr.io/r/base/length.html" class="external-link">length</a></span><span class="op">(</span><span class="va">formula2</span><span class="op">$</span><span class="va">basis_list</span><span class="op">)</span></code></pre></div>
 <pre><code><span class="co">## [1] TRUE</span></code></pre>
-<div class="sourceCode" id="cb52"><pre class="downlit sourceCode r">
+<div class="sourceCode" id="cb54"><pre class="downlit sourceCode r">
 <code class="sourceCode R"><span class="co"># Maybe we only want an additive model for x1 and x2</span>
 <span class="co"># Use the `.` argument</span>
 <span class="va">formula1</span> <span class="op">&lt;-</span> <span class="fu"><a href="../reference/h.html">h</a></span><span class="op">(</span><span class="va">.</span>, . <span class="op">=</span> <span class="fu"><a href="https://rdrr.io/r/base/c.html" class="external-link">c</a></span><span class="op">(</span><span class="st">"x1"</span>, <span class="st">"x2"</span><span class="op">)</span><span class="op">)</span>
@@ -691,19 +694,19 @@ generated by replacing the <code>.</code> with all variables in
 <span class="fu"><a href="https://rdrr.io/r/base/length.html" class="external-link">length</a></span><span class="op">(</span><span class="va">formula1</span><span class="op">$</span><span class="va">basis_list</span> <span class="op">)</span> <span class="op">==</span> <span class="fu"><a href="https://rdrr.io/r/base/length.html" class="external-link">length</a></span><span class="op">(</span><span class="va">formula2</span><span class="op">$</span><span class="va">basis_list</span><span class="op">)</span></code></pre></div>
 <pre><code><span class="co">## [1] TRUE</span></code></pre>
 <p>We can specify interactions as follows.</p>
-<div class="sourceCode" id="cb54"><pre class="downlit sourceCode r">
+<div class="sourceCode" id="cb56"><pre class="downlit sourceCode r">
 <code class="sourceCode R"><span class="co">#  Two way interactions</span>
 <span class="va">formula1</span> <span class="op">&lt;-</span>  <span class="fu"><a href="../reference/h.html">h</a></span><span class="op">(</span><span class="va">x1</span><span class="op">)</span> <span class="op">+</span> <span class="fu"><a href="../reference/h.html">h</a></span><span class="op">(</span><span class="va">x2</span><span class="op">)</span>  <span class="op">+</span> <span class="fu"><a href="../reference/h.html">h</a></span><span class="op">(</span><span class="va">A</span><span class="op">)</span> <span class="op">+</span> <span class="fu"><a href="../reference/h.html">h</a></span><span class="op">(</span><span class="va">x1</span>, <span class="va">x2</span><span class="op">)</span>
 <span class="va">formula2</span> <span class="op">&lt;-</span>  <span class="fu"><a href="../reference/h.html">h</a></span><span class="op">(</span><span class="va">.</span><span class="op">)</span>  <span class="op">+</span> <span class="fu"><a href="../reference/h.html">h</a></span><span class="op">(</span><span class="va">x1</span>, <span class="va">x2</span><span class="op">)</span>
 <span class="fu"><a href="https://rdrr.io/r/base/length.html" class="external-link">length</a></span><span class="op">(</span><span class="va">formula1</span><span class="op">$</span><span class="va">basis_list</span> <span class="op">)</span> <span class="op">==</span> <span class="fu"><a href="https://rdrr.io/r/base/length.html" class="external-link">length</a></span><span class="op">(</span><span class="va">formula2</span><span class="op">$</span><span class="va">basis_list</span><span class="op">)</span></code></pre></div>
 <pre><code><span class="co">## [1] TRUE</span></code></pre>
-<div class="sourceCode" id="cb56"><pre class="downlit sourceCode r">
+<div class="sourceCode" id="cb58"><pre class="downlit sourceCode r">
 <code class="sourceCode R"><span class="co">#</span>
 <span class="va">formula1</span> <span class="op">&lt;-</span>  <span class="fu"><a href="../reference/h.html">h</a></span><span class="op">(</span><span class="va">.</span><span class="op">)</span> <span class="op">+</span> <span class="fu"><a href="../reference/h.html">h</a></span><span class="op">(</span><span class="va">x1</span>, <span class="va">x2</span><span class="op">)</span>    <span class="op">+</span> <span class="fu"><a href="../reference/h.html">h</a></span><span class="op">(</span><span class="va">x1</span>,<span class="va">A</span><span class="op">)</span> <span class="op">+</span> <span class="fu"><a href="../reference/h.html">h</a></span><span class="op">(</span><span class="va">x2</span>,<span class="va">A</span><span class="op">)</span>
 <span class="va">formula2</span> <span class="op">&lt;-</span>  <span class="fu"><a href="../reference/h.html">h</a></span><span class="op">(</span><span class="va">.</span><span class="op">)</span>  <span class="op">+</span> <span class="fu"><a href="../reference/h.html">h</a></span><span class="op">(</span><span class="va">.</span>, <span class="va">.</span><span class="op">)</span>
 <span class="fu"><a href="https://rdrr.io/r/base/length.html" class="external-link">length</a></span><span class="op">(</span><span class="va">formula1</span><span class="op">$</span><span class="va">basis_list</span> <span class="op">)</span> <span class="op">==</span> <span class="fu"><a href="https://rdrr.io/r/base/length.html" class="external-link">length</a></span><span class="op">(</span><span class="va">formula2</span><span class="op">$</span><span class="va">basis_list</span><span class="op">)</span></code></pre></div>
 <pre><code><span class="co">## [1] TRUE</span></code></pre>
-<div class="sourceCode" id="cb58"><pre class="downlit sourceCode r">
+<div class="sourceCode" id="cb60"><pre class="downlit sourceCode r">
 <code class="sourceCode R"><span class="co">#  Three way interactions</span>
 <span class="va">formula1</span> <span class="op">&lt;-</span>  <span class="fu"><a href="../reference/h.html">h</a></span><span class="op">(</span><span class="va">.</span><span class="op">)</span> <span class="op">+</span> <span class="fu"><a href="../reference/h.html">h</a></span><span class="op">(</span><span class="va">.</span>,<span class="va">.</span><span class="op">)</span>    <span class="op">+</span> <span class="fu"><a href="../reference/h.html">h</a></span><span class="op">(</span><span class="va">x1</span>,<span class="va">A</span>,<span class="va">x2</span><span class="op">)</span>  
 <span class="va">formula2</span> <span class="op">&lt;-</span>  <span class="fu"><a href="../reference/h.html">h</a></span><span class="op">(</span><span class="va">.</span><span class="op">)</span>  <span class="op">+</span> <span class="fu"><a href="../reference/h.html">h</a></span><span class="op">(</span><span class="va">.</span>, <span class="va">.</span><span class="op">)</span><span class="op">+</span> <span class="fu"><a href="../reference/h.html">h</a></span><span class="op">(</span><span class="va">.</span>,<span class="va">.</span>,<span class="va">.</span><span class="op">)</span>  
@@ -713,7 +716,7 @@ generated by replacing the <code>.</code> with all variables in
 two-way interactions with one variable (e.g., treatment “A”). This can
 be done in a variety of ways. The <code>.</code> argument allows you to
 specify a subset of variables.</p>
-<div class="sourceCode" id="cb60"><pre class="downlit sourceCode r">
+<div class="sourceCode" id="cb62"><pre class="downlit sourceCode r">
 <code class="sourceCode R"><span class="co"># Write it all out</span>
 <span class="va">formula</span> <span class="op">&lt;-</span>  <span class="fu"><a href="../reference/h.html">h</a></span><span class="op">(</span><span class="va">x1</span><span class="op">)</span> <span class="op">+</span> <span class="fu"><a href="../reference/h.html">h</a></span><span class="op">(</span><span class="va">x2</span><span class="op">)</span> <span class="op">+</span> <span class="fu"><a href="../reference/h.html">h</a></span><span class="op">(</span><span class="va">A</span><span class="op">)</span> <span class="op">+</span> <span class="fu"><a href="../reference/h.html">h</a></span><span class="op">(</span><span class="va">A</span>, <span class="va">x1</span><span class="op">)</span> <span class="op">+</span> <span class="fu"><a href="../reference/h.html">h</a></span><span class="op">(</span><span class="va">A</span>,<span class="va">x2</span><span class="op">)</span>
  
@@ -742,7 +745,7 @@ constraint on the function’s derivative (e.g. a convexity constraint).
 We can also specify that certain terms are not penalized in the
 LASSO/glmnet using the <code>pf</code> argument of <code>h</code>
 (stands for penalty factor).</p>
-<div class="sourceCode" id="cb62"><pre class="downlit sourceCode r">
+<div class="sourceCode" id="cb64"><pre class="downlit sourceCode r">
 <code class="sourceCode R"><span class="co"># An additive monotone increasing model</span>
 <span class="va">formula</span> <span class="op">&lt;-</span> <span class="fu"><a href="../reference/formula_hal.html">formula_hal</a></span><span class="op">(</span>
   <span class="va">y</span> <span class="op">~</span> <span class="fu"><a href="../reference/h.html">h</a></span><span class="op">(</span><span class="va">.</span>, monotone <span class="op">=</span> <span class="st">"i"</span><span class="op">)</span>, <span class="va">X</span>, smoothness_orders <span class="op">=</span> <span class="fl">0</span>, num_knots <span class="op">=</span> <span class="fl">100</span>
@@ -765,7 +768,7 @@ LASSO/glmnet using the <code>pf</code> argument of <code>h</code>
   <span class="op">~</span> <span class="fu"><a href="../reference/h.html">h</a></span><span class="op">(</span><span class="va">.</span>, monotone <span class="op">=</span> <span class="st">"d"</span><span class="op">)</span> <span class="op">+</span> <span class="fu"><a href="../reference/h.html">h</a></span><span class="op">(</span><span class="va">.</span>,<span class="va">.</span>, monotone <span class="op">=</span> <span class="st">"d"</span><span class="op">)</span>, <span class="va">X</span>, smoothness_orders <span class="op">=</span> <span class="fl">1</span>, num_knots <span class="op">=</span> <span class="fl">100</span>
 <span class="op">)</span></code></pre></div>
 <p>The penalization feature can be used to reproduce glm</p>
-<div class="sourceCode" id="cb63"><pre class="downlit sourceCode r">
+<div class="sourceCode" id="cb65"><pre class="downlit sourceCode r">
 <code class="sourceCode R"><span class="co"># Additive glm</span>
 <span class="co"># One knot (at the origin) and first order smoothness</span>
 <span class="va">formula</span> <span class="op">&lt;-</span> <span class="fu"><a href="../reference/h.html">h</a></span><span class="op">(</span><span class="va">.</span>, s <span class="op">=</span> <span class="fl">1</span>, k <span class="op">=</span> <span class="fl">1</span>, pf <span class="op">=</span> <span class="fl">0</span><span class="op">)</span>
@@ -777,7 +780,7 @@ LASSO/glmnet using the <code>pf</code> argument of <code>h</code>
 <p>Now, that we’ve illustrated the options with
 <code>formula_hal</code>, let’s show how to fit a HAL model with the
 specified formula.</p>
-<div class="sourceCode" id="cb64"><pre class="downlit sourceCode r">
+<div class="sourceCode" id="cb66"><pre class="downlit sourceCode r">
 <code class="sourceCode R"><span class="co"># get formula object</span>
 <span class="va">fit</span> <span class="op">&lt;-</span> <span class="fu"><a href="../reference/fit_hal.html">fit_hal</a></span><span class="op">(</span>
   X <span class="op">=</span> <span class="va">X</span>, Y <span class="op">=</span> <span class="va">Y</span>, formula <span class="op">=</span> <span class="op">~</span> <span class="fu"><a href="../reference/h.html">h</a></span><span class="op">(</span><span class="va">.</span><span class="op">)</span>, smoothness_orders <span class="op">=</span> <span class="fl">1</span>, num_knots <span class="op">=</span> <span class="fl">100</span>
@@ -797,7 +800,7 @@ specified formula.</p>
 <span class="co">##   0.2078703 [ I(x2 &gt;= -1.293)*(x2 - -1.293)^1 ]</span>
 <span class="co">##  -0.2039605     [ I(A &gt;= 1.384)*(A - 1.384)^1 ]</span>
 <span class="co">##   0.1993688   [ I(A &gt;= -1.356)*(A - -1.356)^1 ]</span></code></pre>
-<div class="sourceCode" id="cb66"><pre class="downlit sourceCode r">
+<div class="sourceCode" id="cb68"><pre class="downlit sourceCode r">
 <code class="sourceCode R"><span class="fu"><a href="https://rdrr.io/r/graphics/plot.default.html" class="external-link">plot</a></span><span class="op">(</span><span class="fu"><a href="https://rdrr.io/r/stats/predict.html" class="external-link">predict</a></span><span class="op">(</span><span class="va">fit</span>, new_data <span class="op">=</span> <span class="va">X</span><span class="op">)</span>, <span class="va">Y</span><span class="op">)</span></code></pre></div>
 <p><img src="intro_hal9001_files/figure-html/unnamed-chunk-13-1.png" width="700"></p>
 </div>
@@ -848,14 +851,12 @@ van der Laan, Mark J. 2017. <span>“Finite Sample Inference for
 
       <footer><div class="copyright">
   <p></p>
-<p>Developed by Jeremy Coyle, Nima Hejazi, Rachael Phillips, Lars van
-der Laan, Mark van der Laan.</p>
+<p>Developed by Jeremy Coyle, Nima Hejazi, Rachael Phillips, Lars van der Laan, Mark van der Laan.</p>
 </div>
 
 <div class="pkgdown">
   <p></p>
-<p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a>
-2.0.2.</p>
+<p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.3.</p>
 </div>
 
       </footer>

--- a/docs/authors.html
+++ b/docs/authors.html
@@ -23,7 +23,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="index.html">hal9001</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.4.4</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.4.5</span>
       </span>
     </div>
 
@@ -103,20 +103,20 @@
 
     <p>Coyle J, Hejazi N, Phillips R, van der Laan L, van der Laan M (2022).
 <em>hal9001: The scalable highly adaptive lasso</em>.
-doi: <a href="https://doi.org/10.5281/zenodo.3558313" class="external-link">10.5281/zenodo.3558313</a>, R package version 0.4.4, <a href="https://github.com/tlverse/hal9001" class="external-link">https://github.com/tlverse/hal9001</a>. 
+<a href="https://doi.org/10.5281/zenodo.3558313" class="external-link">doi:10.5281/zenodo.3558313</a>, R package version 0.4.5, <a href="https://github.com/tlverse/hal9001" class="external-link">https://github.com/tlverse/hal9001</a>. 
 </p>
     <pre>@Manual{,
   title = {{hal9001}: The scalable highly adaptive lasso},
   author = {Jeremy R Coyle and Nima S Hejazi and Rachael V Phillips and Lars WP {van der Laan} and Mark J {van der Laan}},
   year = {2022},
-  note = {R package version 0.4.4},
+  note = {R package version 0.4.5},
   doi = {10.5281/zenodo.3558313},
   url = {https://github.com/tlverse/hal9001},
 }</pre>
     <p>Hejazi N, Coyle J, van der Laan M (2020).
 “hal9001: Scalable highly adaptive lasso regression in R.”
 <em>Journal of Open Source Software</em>.
-doi: <a href="https://doi.org/10.21105/joss.02526" class="external-link">10.21105/joss.02526</a>, <a href="https://doi.org/10.21105/joss.02526" class="external-link">https://doi.org/10.21105/joss.02526</a>. 
+<a href="https://doi.org/10.21105/joss.02526" class="external-link">doi:10.21105/joss.02526</a>, <a href="https://doi.org/10.21105/joss.02526" class="external-link">https://doi.org/10.21105/joss.02526</a>. 
 </p>
     <pre>@Article{,
   title = {{hal9001}: Scalable highly adaptive lasso regression in {R}},
@@ -135,13 +135,11 @@ doi: <a href="https://doi.org/10.21105/joss.02526" class="external-link">10.2110
 
 
       <footer><div class="copyright">
-  <p></p><p>Developed by Jeremy Coyle, Nima Hejazi, Rachael Phillips, Lars van
-der Laan, Mark van der Laan.</p>
+  <p></p><p>Developed by Jeremy Coyle, Nima Hejazi, Rachael Phillips, Lars van der Laan, Mark van der Laan.</p>
 </div>
 
 <div class="pkgdown">
-  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a>
-2.0.2.</p>
+  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.3.</p>
 </div>
 
       </footer></div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -143,12 +143,12 @@
 <span class="co">#&gt; [1] "I'm sorry, Dave. I'm afraid I can't do that."</span>
 <span class="va">hal_fit</span><span class="op">$</span><span class="va">times</span>
 <span class="co">#&gt;                   user.self sys.self elapsed user.child sys.child</span>
-<span class="co">#&gt; enumerate_basis       0.012    0.003   0.020          0         0</span>
-<span class="co">#&gt; design_matrix         0.004    0.000   0.004          0         0</span>
-<span class="co">#&gt; reduce_basis          0.000    0.000   0.001          0         0</span>
+<span class="co">#&gt; enumerate_basis       0.014    0.003   0.059          0         0</span>
+<span class="co">#&gt; design_matrix         0.004    0.001   0.005          0         0</span>
+<span class="co">#&gt; reduce_basis          0.000    0.000   0.000          0         0</span>
 <span class="co">#&gt; remove_duplicates     0.000    0.000   0.000          0         0</span>
-<span class="co">#&gt; lasso                 2.660    0.272   4.215          0         0</span>
-<span class="co">#&gt; total                 2.677    0.276   4.240          0         0</span>
+<span class="co">#&gt; lasso                 2.684    0.343   6.583          0         0</span>
+<span class="co">#&gt; total                 2.703    0.348   6.655          0         0</span>
 
 <span class="co"># training sample prediction</span>
 <span class="va">preds</span> <span class="op">&lt;-</span> <span class="fu"><a href="https://rdrr.io/r/stats/predict.html" class="external-link">predict</a></span><span class="op">(</span><span class="va">hal_fit</span>, new_data <span class="op">=</span> <span class="va">x</span><span class="op">)</span>

--- a/docs/index.html
+++ b/docs/index.html
@@ -49,7 +49,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="index.html">hal9001</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.4.4</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.4.5</span>
       </span>
     </div>
 
@@ -95,29 +95,12 @@
 <blockquote>
 <p>The <em>Scalable</em> Highly Adaptive Lasso</p>
 </blockquote>
-<p><strong>Authors:</strong> <a href="https://github.com/tlverse" class="external-link">Jeremy
-Coyle</a>, <a href="https://nimahejazi.org" class="external-link">Nima Hejazi</a>, <a href="https://github.com/rachaelvp" class="external-link">Rachael Phillips</a>, <a href="https://github.com/Larsvanderlaan" class="external-link">Lars van der Laan</a>, and <a href="https://vanderlaan-lab.org/" class="external-link">Mark van der Laan</a></p>
+<p><strong>Authors:</strong> <a href="https://github.com/tlverse" class="external-link">Jeremy Coyle</a>, <a href="https://nimahejazi.org" class="external-link">Nima Hejazi</a>, <a href="https://github.com/rachaelvp" class="external-link">Rachael Phillips</a>, <a href="https://github.com/Larsvanderlaan" class="external-link">Lars van der Laan</a>, and <a href="https://vanderlaan-lab.org/" class="external-link">Mark van der Laan</a></p>
 <hr>
 <div class="section level2">
 <h2 id="whats-hal9001">What’s <code>hal9001</code>?<a class="anchor" aria-label="anchor" href="#whats-hal9001"></a>
 </h2>
-<p><code>hal9001</code> is an R package providing an implementation of
-the scalable <em>highly adaptive lasso</em> (HAL), a nonparametric
-regression estimator that applies L1-regularized lasso regression to a
-design matrix composed of indicator functions corresponding to the
-support of the functional over a set of covariates and interactions
-thereof. HAL regression allows for arbitrarily complex functional forms
-to be estimated at fast (near-parametric) convergence rates under only
-global smoothness assumptions (van der Laan 2017a; Bibaut and van der
-Laan 2019). For detailed theoretical discussions of the highly adaptive
-lasso estimator, consider consulting, for example, van der Laan (2017a),
-van der Laan (2017b), and van der Laan and Bibaut (2017). For a
-computational demonstration of the versatility of HAL regression, see
-Benkeser and van der Laan (2016). Recent theoretical works have
-demonstrated success in building efficient estimators of complex
-parameters when particular variations of HAL regression are used to
-estimate nuisance parameters (e.g., van der Laan, Benkeser, and Cai
-2019; Ertefaie, Hejazi, and van der Laan 2020).</p>
+<p><code>hal9001</code> is an R package providing an implementation of the scalable <em>highly adaptive lasso</em> (HAL), a nonparametric regression estimator that applies L1-regularized lasso regression to a design matrix composed of indicator functions corresponding to the support of the functional over a set of covariates and interactions thereof. HAL regression allows for arbitrarily complex functional forms to be estimated at fast (near-parametric) convergence rates under only global smoothness assumptions (van der Laan 2017a; Bibaut and van der Laan 2019). For detailed theoretical discussions of the highly adaptive lasso estimator, consider consulting, for example, van der Laan (2017a), van der Laan (2017b), and van der Laan and Bibaut (2017). For a computational demonstration of the versatility of HAL regression, see Benkeser and van der Laan (2016). Recent theoretical works have demonstrated success in building efficient estimators of complex parameters when particular variations of HAL regression are used to estimate nuisance parameters (e.g., van der Laan, Benkeser, and Cai 2019; Ertefaie, Hejazi, and van der Laan 2020).</p>
 <hr>
 </div>
 <div class="section level2">
@@ -126,8 +109,7 @@ estimate nuisance parameters (e.g., van der Laan, Benkeser, and Cai
 <p>For standard use, we recommend installing the package from <a href="https://CRAN.R-project.org/package=hal9001" class="external-link">CRAN</a> via</p>
 <div class="sourceCode" id="cb1"><pre class="downlit sourceCode r">
 <code class="sourceCode R"><span class="fu"><a href="https://rdrr.io/r/utils/install.packages.html" class="external-link">install.packages</a></span><span class="op">(</span><span class="st">"hal9001"</span><span class="op">)</span></code></pre></div>
-<p>To contribute, install the <em>development version</em> of
-<code>hal9001</code> from GitHub via <a href="https://CRAN.R-project.org/package=remotes" class="external-link"><code>remotes</code></a>:</p>
+<p>To contribute, install the <em>development version</em> of <code>hal9001</code> from GitHub via <a href="https://CRAN.R-project.org/package=remotes" class="external-link"><code>remotes</code></a>:</p>
 <div class="sourceCode" id="cb2"><pre class="downlit sourceCode r">
 <code class="sourceCode R"><span class="fu">remotes</span><span class="fu">::</span><span class="fu"><a href="https://remotes.r-lib.org/reference/install_github.html" class="external-link">install_github</a></span><span class="op">(</span><span class="st">"tlverse/hal9001"</span><span class="op">)</span></code></pre></div>
 <hr>
@@ -135,21 +117,18 @@ estimate nuisance parameters (e.g., van der Laan, Benkeser, and Cai
 <div class="section level2">
 <h2 id="issues">Issues<a class="anchor" aria-label="anchor" href="#issues"></a>
 </h2>
-<p>If you encounter any bugs or have any specific feature requests,
-please <a href="https://github.com/tlverse/hal9001/issues" class="external-link">file an
-issue</a>.</p>
+<p>If you encounter any bugs or have any specific feature requests, please <a href="https://github.com/tlverse/hal9001/issues" class="external-link">file an issue</a>.</p>
 <hr>
 </div>
 <div class="section level2">
 <h2 id="example">Example<a class="anchor" aria-label="anchor" href="#example"></a>
 </h2>
-<p>Consider the following minimal example in using <code>hal9001</code>
-to generate predictions via Highly Adaptive Lasso regression:</p>
+<p>Consider the following minimal example in using <code>hal9001</code> to generate predictions via Highly Adaptive Lasso regression:</p>
 <div class="sourceCode" id="cb3"><pre class="downlit sourceCode r">
 <code class="sourceCode R"><span class="co"># load the package and set a seed</span>
 <span class="kw"><a href="https://rdrr.io/r/base/library.html" class="external-link">library</a></span><span class="op">(</span><span class="va"><a href="https://github.com/tlverse/hal9001" class="external-link">hal9001</a></span><span class="op">)</span>
 <span class="co">#&gt; Loading required package: Rcpp</span>
-<span class="co">#&gt; hal9001 v0.4.3: The Scalable Highly Adaptive Lasso</span>
+<span class="co">#&gt; hal9001 v0.4.4: The Scalable Highly Adaptive Lasso</span>
 <span class="co">#&gt; note: fit_hal defaults have changed. See ?fit_hal for details</span>
 <span class="fu"><a href="https://rdrr.io/r/base/Random.html" class="external-link">set.seed</a></span><span class="op">(</span><span class="fl">385971</span><span class="op">)</span>
 
@@ -164,32 +143,29 @@ to generate predictions via Highly Adaptive Lasso regression:</p>
 <span class="co">#&gt; [1] "I'm sorry, Dave. I'm afraid I can't do that."</span>
 <span class="va">hal_fit</span><span class="op">$</span><span class="va">times</span>
 <span class="co">#&gt;                   user.self sys.self elapsed user.child sys.child</span>
-<span class="co">#&gt; enumerate_basis       0.007    0.000   0.007          0         0</span>
-<span class="co">#&gt; design_matrix         0.003    0.000   0.003          0         0</span>
-<span class="co">#&gt; reduce_basis          0.000    0.000   0.000          0         0</span>
+<span class="co">#&gt; enumerate_basis       0.012    0.003   0.020          0         0</span>
+<span class="co">#&gt; design_matrix         0.004    0.000   0.004          0         0</span>
+<span class="co">#&gt; reduce_basis          0.000    0.000   0.001          0         0</span>
 <span class="co">#&gt; remove_duplicates     0.000    0.000   0.000          0         0</span>
-<span class="co">#&gt; lasso                 1.499    0.024   1.529          0         0</span>
-<span class="co">#&gt; total                 1.509    0.024   1.539          0         0</span>
+<span class="co">#&gt; lasso                 2.660    0.272   4.215          0         0</span>
+<span class="co">#&gt; total                 2.677    0.276   4.240          0         0</span>
 
 <span class="co"># training sample prediction</span>
 <span class="va">preds</span> <span class="op">&lt;-</span> <span class="fu"><a href="https://rdrr.io/r/stats/predict.html" class="external-link">predict</a></span><span class="op">(</span><span class="va">hal_fit</span>, new_data <span class="op">=</span> <span class="va">x</span><span class="op">)</span>
 <span class="fu"><a href="https://rdrr.io/r/base/mean.html" class="external-link">mean</a></span><span class="op">(</span><span class="va">hal_mse</span> <span class="op">&lt;-</span> <span class="op">(</span><span class="va">preds</span> <span class="op">-</span> <span class="va">y</span><span class="op">)</span><span class="op">^</span><span class="fl">2</span><span class="op">)</span>
-<span class="co">#&gt; [1] 0.03754093</span></code></pre></div>
+<span class="co">#&gt; [1] 0.03667466</span></code></pre></div>
 <hr>
 </div>
 <div class="section level2">
 <h2 id="contributions">Contributions<a class="anchor" aria-label="anchor" href="#contributions"></a>
 </h2>
-<p>Contributions are very welcome. Interested contributors should
-consult our <a href="https://github.com/tlverse/hal9001/blob/master/CONTRIBUTING.md" class="external-link">contribution
-guidelines</a> prior to submitting a pull request.</p>
+<p>Contributions are very welcome. Interested contributors should consult our <a href="https://github.com/tlverse/hal9001/blob/master/CONTRIBUTING.md" class="external-link">contribution guidelines</a> prior to submitting a pull request.</p>
 <hr>
 </div>
 <div class="section level2">
 <h2 id="citation">Citation<a class="anchor" aria-label="anchor" href="#citation"></a>
 </h2>
-<p>After using the <code>hal9001</code> R package, please cite both of
-the following:</p>
+<p>After using the <code>hal9001</code> R package, please cite both of the following:</p>
 <div class="sourceCode" id="cb4"><pre class="sourceCode R"><code class="sourceCode r"><span id="cb4-1"><a href="#cb4-1" aria-hidden="true" tabindex="-1"></a>    <span class="sc">@</span>software{coyle2022hal9001<span class="sc">-</span>rpkg,</span>
 <span id="cb4-2"><a href="#cb4-2" aria-hidden="true" tabindex="-1"></a>      author <span class="ot">=</span> {Coyle, Jeremy R and Hejazi, Nima S and Phillips, Rachael V</span>
 <span id="cb4-3"><a href="#cb4-3" aria-hidden="true" tabindex="-1"></a>        and {van der Laan}, Lars and {van der Laan}, Mark J},</span>
@@ -216,10 +192,8 @@ the following:</p>
 <div class="section level2">
 <h2 id="license">License<a class="anchor" aria-label="anchor" href="#license"></a>
 </h2>
-<p>© 2017-2022 <a href="https://github.com/tlverse" class="external-link">Jeremy R. Coyle</a>
-&amp; <a href="https://nimahejazi.org" class="external-link">Nima S. Hejazi</a></p>
-<p>The contents of this repository are distributed under the GPL-3
-license. See file <code>LICENSE</code> for details.</p>
+<p>© 2017-2022 <a href="https://github.com/tlverse" class="external-link">Jeremy R. Coyle</a> &amp; <a href="https://nimahejazi.org" class="external-link">Nima S. Hejazi</a></p>
+<p>The contents of this repository are distributed under the GPL-3 license. See file <code>LICENSE</code> for details.</p>
 <hr>
 </div>
 <div class="section level2">
@@ -227,37 +201,25 @@ license. See file <code>LICENSE</code> for details.</p>
 </h2>
 <div id="refs" class="references csl-bib-body hanging-indent">
 <div id="ref-benkeser2016hal" class="csl-entry">
-Benkeser, David, and Mark J van der Laan. 2016. “The Highly Adaptive
-Lasso Estimator.” In <em>2016 IEEE International Conference on Data
-Science and Advanced Analytics (DSAA)</em>. IEEE. <a href="https://doi.org/10.1109/dsaa.2016.93" class="external-link uri">https://doi.org/10.1109/dsaa.2016.93</a>.
+Benkeser, David, and Mark J van der Laan. 2016. “The Highly Adaptive Lasso Estimator.” In <em>2016 IEEE International Conference on Data Science and Advanced Analytics (DSAA)</em>. IEEE. <a href="https://doi.org/10.1109/dsaa.2016.93" class="external-link uri">https://doi.org/10.1109/dsaa.2016.93</a>.
 </div>
 <div id="ref-bibaut2019fast" class="csl-entry">
-Bibaut, Aurélien F, and Mark J van der Laan. 2019. “Fast Rates for
-Empirical Risk Minimization over Càdlàg Functions with Bounded Sectional
-Variation Norm.” <a href="https://arxiv.org/abs/1907.09244" class="external-link uri">https://arxiv.org/abs/1907.09244</a>.
+Bibaut, Aurélien F, and Mark J van der Laan. 2019. “Fast Rates for Empirical Risk Minimization over Càdlàg Functions with Bounded Sectional Variation Norm.” <a href="https://arxiv.org/abs/1907.09244" class="external-link uri">https://arxiv.org/abs/1907.09244</a>.
 </div>
 <div id="ref-ertefaie2020nonparametric" class="csl-entry">
-Ertefaie, Ashkan, Nima S Hejazi, and Mark J van der Laan. 2020.
-“Nonparametric Inverse Probability Weighted Estimators Based on the
-Highly Adaptive Lasso.” <a href="https://arxiv.org/abs/2005.11303" class="external-link uri">https://arxiv.org/abs/2005.11303</a>.
+Ertefaie, Ashkan, Nima S Hejazi, and Mark J van der Laan. 2020. “Nonparametric Inverse Probability Weighted Estimators Based on the Highly Adaptive Lasso.” <a href="https://arxiv.org/abs/2005.11303" class="external-link uri">https://arxiv.org/abs/2005.11303</a>.
 </div>
 <div id="ref-vdl2017generally" class="csl-entry">
-van der Laan, Mark J. 2017a. “A Generally Efficient Targeted Minimum
-Loss Based Estimator Based on the Highly Adaptive Lasso.” <em>The
-International Journal of Biostatistics</em>. <a href="https://doi.org/10.1515/ijb-2015-0097" class="external-link uri">https://doi.org/10.1515/ijb-2015-0097</a>.
+van der Laan, Mark J. 2017a. “A Generally Efficient Targeted Minimum Loss Based Estimator Based on the Highly Adaptive Lasso.” <em>The International Journal of Biostatistics</em>. <a href="https://doi.org/10.1515/ijb-2015-0097" class="external-link uri">https://doi.org/10.1515/ijb-2015-0097</a>.
 </div>
 <div id="ref-vdl2017finite" class="csl-entry">
 ———. 2017b. “Finite Sample Inference for Targeted Learning.” <a href="https://arxiv.org/abs/1708.09502" class="external-link uri">https://arxiv.org/abs/1708.09502</a>.
 </div>
 <div id="ref-vdl2019efficient" class="csl-entry">
-van der Laan, Mark J, David Benkeser, and Weixin Cai. 2019. “Efficient
-Estimation of Pathwise Differentiable Target Parameters with the
-Undersmoothed Highly Adaptive Lasso.” <a href="https://arxiv.org/abs/1908.05607" class="external-link uri">https://arxiv.org/abs/1908.05607</a>.
+van der Laan, Mark J, David Benkeser, and Weixin Cai. 2019. “Efficient Estimation of Pathwise Differentiable Target Parameters with the Undersmoothed Highly Adaptive Lasso.” <a href="https://arxiv.org/abs/1908.05607" class="external-link uri">https://arxiv.org/abs/1908.05607</a>.
 </div>
 <div id="ref-vdl2017uniform" class="csl-entry">
-van der Laan, Mark J, and Aurélien F Bibaut. 2017. “Uniform Consistency
-of the Highly Adaptive Lasso Estimator of Infinite-Dimensional
-Parameters.” <a href="https://arxiv.org/abs/1709.06256" class="external-link uri">https://arxiv.org/abs/1709.06256</a>.
+van der Laan, Mark J, and Aurélien F Bibaut. 2017. “Uniform Consistency of the Highly Adaptive Lasso Estimator of Infinite-Dimensional Parameters.” <a href="https://arxiv.org/abs/1709.06256" class="external-link uri">https://arxiv.org/abs/1709.06256</a>.
 </div>
 </div>
 </div>
@@ -328,14 +290,12 @@ Parameters.” <a href="https://arxiv.org/abs/1709.06256" class="external-link u
 
       <footer><div class="copyright">
   <p></p>
-<p>Developed by Jeremy Coyle, Nima Hejazi, Rachael Phillips, Lars van
-der Laan, Mark van der Laan.</p>
+<p>Developed by Jeremy Coyle, Nima Hejazi, Rachael Phillips, Lars van der Laan, Mark van der Laan.</p>
 </div>
 
 <div class="pkgdown">
   <p></p>
-<p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a>
-2.0.2.</p>
+<p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.3.</p>
 </div>
 
       </footer>

--- a/docs/news/index.html
+++ b/docs/news/index.html
@@ -23,7 +23,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">hal9001</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.4.4</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.4.5</span>
       </span>
     </div>
 
@@ -60,21 +60,14 @@
     </div>
 
     <div class="section level2">
+<h2 class="page-header" data-toc-text="0.4.5" id="hal9001-045">hal9001 0.4.5<a class="anchor" aria-label="anchor" href="#hal9001-045"></a></h2>
+<ul><li>Added multivariate outcome prediction</li>
+</ul></div>
+    <div class="section level2">
 <h2 class="page-header" data-toc-text="0.4.4" id="hal9001-044">hal9001 0.4.4<a class="anchor" aria-label="anchor" href="#hal9001-044"></a></h2>
-<ul><li>Fixed bug with <code>prediction_bounds</code> (a
-<code>fit_hal</code> argument in <code>fit_control</code> list), which
-would error when it was specified as a numeric vector. Also, added a
-check to assert this argument is correctly specified, and tests to
-ensure a numeric vector of bounds is provided.</li>
-<li>Simplified <code>fit_control</code> list arguments in
-<code>fit_hal</code>. Users can still specify additional arguments to
-<code>cv.glmnet</code> and <code>glmnet</code> in this list.</li>
-<li>Defined <code>weights</code> as a formal argument in
-<code>fit_hal</code>, opposed to an optional argument in
-<code>fit_control</code>, to facilitate specification and avoid
-confusion. This increases flexibility with SuperLearner wrapper
-<code>SL.hal9001</code> as well; <code>fit_control</code> can now be
-customized with <code>SL.hal9001</code>.</li>
+<ul><li>Fixed bug with <code>prediction_bounds</code> (a <code>fit_hal</code> argument in <code>fit_control</code> list), which would error when it was specified as a numeric vector. Also, added a check to assert this argument is correctly specified, and tests to ensure a numeric vector of bounds is provided.</li>
+<li>Simplified <code>fit_control</code> list arguments in <code>fit_hal</code>. Users can still specify additional arguments to <code>cv.glmnet</code> and <code>glmnet</code> in this list.</li>
+<li>Defined <code>weights</code> as a formal argument in <code>fit_hal</code>, opposed to an optional argument in <code>fit_control</code>, to facilitate specification and avoid confusion. This increases flexibility with SuperLearner wrapper <code>SL.hal9001</code> as well; <code>fit_control</code> can now be customized with <code>SL.hal9001</code>.</li>
 </ul></div>
     <div class="section level2">
 <h2 class="page-header" data-toc-text="0.4.3" id="hal9001-043">hal9001 0.4.3<small>2022-02-09</small><a class="anchor" aria-label="anchor" href="#hal9001-043"></a></h2>
@@ -91,88 +84,24 @@ customized with <code>SL.hal9001</code>.</li>
 </ul></div>
     <div class="section level2">
 <h2 class="page-header" data-toc-text="0.4.0" id="hal9001-040">hal9001 0.4.0<a class="anchor" aria-label="anchor" href="#hal9001-040"></a></h2>
-<p>As of September 2021: * Minor change to how binning is performed when
-<code>num_knots = 1</code>, ensuring that the minimal number of knots is
-chosen when <code>num_knots = 1</code>. This results in HAL agreeing
-with (main terms) <code>glmnet</code> when <code>smoothness_orders =
-1</code> and <code>num_knots = 1</code>. * Revised formula interface
-with enhanced capabilities, allowing specifciation of penalization
-factors, smoothness_orders, and the number of knots for each variable,
-for every single term separately using the new <code>h</code> function.
-It is possible to specify, e.g., <code>h(X) + h(W)</code> which will
-generate and concatenate the two basis function terms.</p>
-<p>As of April 2021: * The default of <code>fit_hal</code> is now a
-first order smoothed HAL with binning. * Updated documentation for
-<code>formula_hal</code>, <code>fit_hal</code> and <code>predict</code>;
-and added <code>fit_control</code> and <code>formula_control</code>
-lists for arguments. Moved much of the text to details sections, and
-shortened the argument descriptions. * Updated <code>summary</code> to
-support higher-order HAL fit interpretations. * Added checks to
-<code>fit_hal</code> for missingness and dimensionality correspondence
-between <code>X</code>, <code>Y</code>, and <code>X_unpenalized</code>.
-These checks lead to quickly-produced errors, opposed to enumerating the
-basis list and then letting <code>glmnet</code> error on something
-trivial like this. * Modified formula interface in <code>fit_hal</code>,
-so <code>formula</code> is now provided directly to <code>fit_hal</code>
-and <code>formula_hal</code> is run within <code>fit_hal</code>. Due to
-these changes, it no longer made sense for <code>formula_hal</code> to
-accept <code>data</code>, so it now takes as input <code>X</code>. Also,
-the <code>formula_fit_hal</code> function was removed as it is no longer
-needed. * Support for the custom lasso procedure implemented in
-<code>Rcpp</code> has been discontinued. Accordingly, the
-<code>"lassi"</code> option and argument <code>fit_type</code> have been
-removed from <code>fit_hal</code>. * Re-added
-<code>lambda.min.ratio</code> as a <code>fit_control</code> argument to
-<code>fit_hal</code>. We’ve seen that not setting
-<code>lambda.min.ratio</code> in <code>glmnet</code> can lead to no
-<code>lambda</code> values that fit the data sufficiently well, so it
-seems appropriate to override the <code>glmnet</code> default.</p>
+<p>As of September 2021: * Minor change to how binning is performed when <code>num_knots = 1</code>, ensuring that the minimal number of knots is chosen when <code>num_knots = 1</code>. This results in HAL agreeing with (main terms) <code>glmnet</code> when <code>smoothness_orders = 1</code> and <code>num_knots = 1</code>. * Revised formula interface with enhanced capabilities, allowing specifciation of penalization factors, smoothness_orders, and the number of knots for each variable, for every single term separately using the new <code>h</code> function. It is possible to specify, e.g., <code>h(X) + h(W)</code> which will generate and concatenate the two basis function terms.</p>
+<p>As of April 2021: * The default of <code>fit_hal</code> is now a first order smoothed HAL with binning. * Updated documentation for <code>formula_hal</code>, <code>fit_hal</code> and <code>predict</code>; and added <code>fit_control</code> and <code>formula_control</code> lists for arguments. Moved much of the text to details sections, and shortened the argument descriptions. * Updated <code>summary</code> to support higher-order HAL fit interpretations. * Added checks to <code>fit_hal</code> for missingness and dimensionality correspondence between <code>X</code>, <code>Y</code>, and <code>X_unpenalized</code>. These checks lead to quickly-produced errors, opposed to enumerating the basis list and then letting <code>glmnet</code> error on something trivial like this. * Modified formula interface in <code>fit_hal</code>, so <code>formula</code> is now provided directly to <code>fit_hal</code> and <code>formula_hal</code> is run within <code>fit_hal</code>. Due to these changes, it no longer made sense for <code>formula_hal</code> to accept <code>data</code>, so it now takes as input <code>X</code>. Also, the <code>formula_fit_hal</code> function was removed as it is no longer needed. * Support for the custom lasso procedure implemented in <code>Rcpp</code> has been discontinued. Accordingly, the <code>"lassi"</code> option and argument <code>fit_type</code> have been removed from <code>fit_hal</code>. * Re-added <code>lambda.min.ratio</code> as a <code>fit_control</code> argument to <code>fit_hal</code>. We’ve seen that not setting <code>lambda.min.ratio</code> in <code>glmnet</code> can lead to no <code>lambda</code> values that fit the data sufficiently well, so it seems appropriate to override the <code>glmnet</code> default.</p>
 </div>
     <div class="section level2">
 <h2 class="page-header" data-toc-text="0.3.0" id="hal9001-030">hal9001 0.3.0<a class="anchor" aria-label="anchor" href="#hal9001-030"></a></h2>
-<p>As of February 2021: * Support <em>higher order</em> HAL via the new
-<code>smoothness_orders</code> argument * <code>smoothness_orders</code>
-is a vector of length 1 or length <code>ncol(X)</code>. * If
-<code>smoothness_orders</code> is of length 1 then its values are
-recycled to form a vector of length <code>ncol(X)</code>. * Given such a
-vector of length <code>ncol(X)</code>, the ith element gives the level
-of smoothness for the variable corresponding to the ith column in
-<code>X</code>. * Degree-dependant binning. Higher order terms are
-binned more coarsely; the <code>num_knots</code> argument is a vector up
-to <code>max_degree</code> controlling the degree-specific binning. *
-Adds <code>formula_hal</code> which allows a formula specification of a
-HAL model.</p>
+<p>As of February 2021: * Support <em>higher order</em> HAL via the new <code>smoothness_orders</code> argument * <code>smoothness_orders</code> is a vector of length 1 or length <code>ncol(X)</code>. * If <code>smoothness_orders</code> is of length 1 then its values are recycled to form a vector of length <code>ncol(X)</code>. * Given such a vector of length <code>ncol(X)</code>, the ith element gives the level of smoothness for the variable corresponding to the ith column in <code>X</code>. * Degree-dependant binning. Higher order terms are binned more coarsely; the <code>num_knots</code> argument is a vector up to <code>max_degree</code> controlling the degree-specific binning. * Adds <code>formula_hal</code> which allows a formula specification of a HAL model.</p>
 </div>
     <div class="section level2">
 <h2 class="page-header" data-toc-text="0.2.8" id="hal9001-028">hal9001 0.2.8<a class="anchor" aria-label="anchor" href="#hal9001-028"></a></h2>
-<p>As of November 2020: * Allow support for Poisson family to
-<code>glmnet()</code>. * Begins consideration of supporting arbitrary
-<code><a href="https://rdrr.io/r/stats/family.html" class="external-link">stats::family()</a></code> objects to be passed through to calls to
-<code>glmnet()</code>. * Simplifies output of <code><a href="../reference/fit_hal.html">fit_hal()</a></code> by
-unifying the redundant <code>hal_lasso</code> and
-<code>glmnet_lasso</code> slots into the new <code>lasso_fit</code>
-slot. * Cleans up of methods throughout and improves documentation,
-reducing a few redundancies for cleaner/simpler code in
-<code>summary.hal9001</code>. * Adds link to DOI of the published
-<em>Journal of Open Source Software</em> paper in
-<code>DESCRIPTION</code>.</p>
+<p>As of November 2020: * Allow support for Poisson family to <code>glmnet()</code>. * Begins consideration of supporting arbitrary <code><a href="https://rdrr.io/r/stats/family.html" class="external-link">stats::family()</a></code> objects to be passed through to calls to <code>glmnet()</code>. * Simplifies output of <code><a href="../reference/fit_hal.html">fit_hal()</a></code> by unifying the redundant <code>hal_lasso</code> and <code>glmnet_lasso</code> slots into the new <code>lasso_fit</code> slot. * Cleans up of methods throughout and improves documentation, reducing a few redundancies for cleaner/simpler code in <code>summary.hal9001</code>. * Adds link to DOI of the published <em>Journal of Open Source Software</em> paper in <code>DESCRIPTION</code>.</p>
 </div>
     <div class="section level2">
 <h2 class="page-header" data-toc-text="0.2.7" id="hal9001-027">hal9001 0.2.7<small>2021-01-22</small><a class="anchor" aria-label="anchor" href="#hal9001-027"></a></h2>
-<p>As of September 2020: * Adds a <code>summary</code> method for
-interpreting HAL regressions (<a href="https://github.com/tlverse/hal9001/pull/64" class="external-link uri">https://github.com/tlverse/hal9001/pull/64</a>). * Adds a
-software paper for publication in the <em>Journal of Open Source
-Software</em> (<a href="https://github.com/tlverse/hal9001/pull/71" class="external-link uri">https://github.com/tlverse/hal9001/pull/71</a>).</p>
+<p>As of September 2020: * Adds a <code>summary</code> method for interpreting HAL regressions (<a href="https://github.com/tlverse/hal9001/pull/64" class="external-link uri">https://github.com/tlverse/hal9001/pull/64</a>). * Adds a software paper for publication in the <em>Journal of Open Source Software</em> (<a href="https://github.com/tlverse/hal9001/pull/71" class="external-link uri">https://github.com/tlverse/hal9001/pull/71</a>).</p>
 </div>
     <div class="section level2">
 <h2 class="page-header" data-toc-text="0.2.6" id="hal9001-026">hal9001 0.2.6<small>2020-06-27</small><a class="anchor" aria-label="anchor" href="#hal9001-026"></a></h2>
-<p>As of June 2020: * Address bugs/inconsistencies reported in the
-prediction method when trying to specify a value of lambda not included
-in initial fitting. * Addresses a bug arising from a silent failure in
-<code>glmnet</code> in which it ignores the argument
-<code>lambda.min.ratio</code> when <code>family = "gaussian"</code> is
-not set. * Adds a short software paper for submission to JOSS. * Minor
-documentation updates.</p>
+<p>As of June 2020: * Address bugs/inconsistencies reported in the prediction method when trying to specify a value of lambda not included in initial fitting. * Addresses a bug arising from a silent failure in <code>glmnet</code> in which it ignores the argument <code>lambda.min.ratio</code> when <code>family = "gaussian"</code> is not set. * Adds a short software paper for submission to JOSS. * Minor documentation updates.</p>
 </div>
     <div class="section level2">
 <h2 class="page-header" data-toc-text="0.2.5" id="hal9001-025">hal9001 0.2.5<small>2020-03-05</small><a class="anchor" aria-label="anchor" href="#hal9001-025"></a></h2>
@@ -188,13 +117,11 @@ documentation updates.</p>
 
 
       <footer><div class="copyright">
-  <p></p><p>Developed by Jeremy Coyle, Nima Hejazi, Rachael Phillips, Lars van
-der Laan, Mark van der Laan.</p>
+  <p></p><p>Developed by Jeremy Coyle, Nima Hejazi, Rachael Phillips, Lars van der Laan, Mark van der Laan.</p>
 </div>
 
 <div class="pkgdown">
-  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a>
-2.0.2.</p>
+  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.3.</p>
 </div>
 
       </footer></div>

--- a/docs/pkgdown.yml
+++ b/docs/pkgdown.yml
@@ -3,7 +3,7 @@ pkgdown: 2.0.3
 pkgdown_sha: ~
 articles:
   intro_hal9001: intro_hal9001.html
-last_built: 2022-07-12T20:23Z
+last_built: 2022-07-13T01:48Z
 urls:
   reference: https://tlverse.org/hal9001/reference
   article: https://tlverse.org/hal9001/articles

--- a/docs/pkgdown.yml
+++ b/docs/pkgdown.yml
@@ -1,9 +1,9 @@
 pandoc: 2.17.0.1
-pkgdown: 2.0.2
+pkgdown: 2.0.3
 pkgdown_sha: ~
 articles:
   intro_hal9001: intro_hal9001.html
-last_built: 2022-03-29T22:20Z
+last_built: 2022-07-12T20:23Z
 urls:
   reference: https://tlverse.org/hal9001/reference
   article: https://tlverse.org/hal9001/articles

--- a/docs/reference/SL.hal9001.html
+++ b/docs/reference/SL.hal9001.html
@@ -23,7 +23,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">hal9001</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.4.4</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.4.5</span>
       </span>
     </div>
 
@@ -126,13 +126,11 @@ covariate for generating basis functions. See <code>num_knots</code> argument in
 
 
       <footer><div class="copyright">
-  <p></p><p>Developed by Jeremy Coyle, Nima Hejazi, Rachael Phillips, Lars van
-der Laan, Mark van der Laan.</p>
+  <p></p><p>Developed by Jeremy Coyle, Nima Hejazi, Rachael Phillips, Lars van der Laan, Mark van der Laan.</p>
 </div>
 
 <div class="pkgdown">
-  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a>
-2.0.2.</p>
+  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.3.</p>
 </div>
 
       </footer></div>

--- a/docs/reference/apply_copy_map.html
+++ b/docs/reference/apply_copy_map.html
@@ -23,7 +23,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">hal9001</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.4.4</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.4.5</span>
       </span>
     </div>
 
@@ -116,13 +116,11 @@ for a zero-th order highly adaptive lasso, but with all duplicated columns
 
 
       <footer><div class="copyright">
-  <p></p><p>Developed by Jeremy Coyle, Nima Hejazi, Rachael Phillips, Lars van
-der Laan, Mark van der Laan.</p>
+  <p></p><p>Developed by Jeremy Coyle, Nima Hejazi, Rachael Phillips, Lars van der Laan, Mark van der Laan.</p>
 </div>
 
 <div class="pkgdown">
-  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a>
-2.0.2.</p>
+  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.3.</p>
 </div>
 
       </footer></div>

--- a/docs/reference/as_dgCMatrix.html
+++ b/docs/reference/as_dgCMatrix.html
@@ -25,7 +25,7 @@ INTERNAL USE ONLY."><!-- mathjax --><script src="https://cdnjs.cloudflare.com/aj
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">hal9001</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.4.4</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.4.5</span>
       </span>
     </div>
 
@@ -91,13 +91,11 @@ suitable for coercion to a sparse matrix format of <code>dgCMatrix</code>.</p></
 
 
       <footer><div class="copyright">
-  <p></p><p>Developed by Jeremy Coyle, Nima Hejazi, Rachael Phillips, Lars van
-der Laan, Mark van der Laan.</p>
+  <p></p><p>Developed by Jeremy Coyle, Nima Hejazi, Rachael Phillips, Lars van der Laan, Mark van der Laan.</p>
 </div>
 
 <div class="pkgdown">
-  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a>
-2.0.2.</p>
+  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.3.</p>
 </div>
 
       </footer></div>

--- a/docs/reference/basis_list_cols.html
+++ b/docs/reference/basis_list_cols.html
@@ -23,7 +23,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">hal9001</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.4.4</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.4.5</span>
       </span>
     </div>
 
@@ -118,13 +118,11 @@ input columns.</p>
 
 
       <footer><div class="copyright">
-  <p></p><p>Developed by Jeremy Coyle, Nima Hejazi, Rachael Phillips, Lars van
-der Laan, Mark van der Laan.</p>
+  <p></p><p>Developed by Jeremy Coyle, Nima Hejazi, Rachael Phillips, Lars van der Laan, Mark van der Laan.</p>
 </div>
 
 <div class="pkgdown">
-  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a>
-2.0.2.</p>
+  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.3.</p>
 </div>
 
       </footer></div>

--- a/docs/reference/basis_of_degree.html
+++ b/docs/reference/basis_of_degree.html
@@ -23,7 +23,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">hal9001</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.4.4</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.4.5</span>
       </span>
     </div>
 
@@ -117,13 +117,11 @@ a set of input columns up to a particular pre-specified degree.</p>
 
 
       <footer><div class="copyright">
-  <p></p><p>Developed by Jeremy Coyle, Nima Hejazi, Rachael Phillips, Lars van
-der Laan, Mark van der Laan.</p>
+  <p></p><p>Developed by Jeremy Coyle, Nima Hejazi, Rachael Phillips, Lars van der Laan, Mark van der Laan.</p>
 </div>
 
 <div class="pkgdown">
-  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a>
-2.0.2.</p>
+  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.3.</p>
 </div>
 
       </footer></div>

--- a/docs/reference/calc_pnz.html
+++ b/docs/reference/calc_pnz.html
@@ -23,7 +23,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">hal9001</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.4.4</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.4.5</span>
       </span>
     </div>
 
@@ -77,13 +77,11 @@
 
 
       <footer><div class="copyright">
-  <p></p><p>Developed by Jeremy Coyle, Nima Hejazi, Rachael Phillips, Lars van
-der Laan, Mark van der Laan.</p>
+  <p></p><p>Developed by Jeremy Coyle, Nima Hejazi, Rachael Phillips, Lars van der Laan, Mark van der Laan.</p>
 </div>
 
 <div class="pkgdown">
-  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a>
-2.0.2.</p>
+  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.3.</p>
 </div>
 
       </footer></div>

--- a/docs/reference/calc_xscale.html
+++ b/docs/reference/calc_xscale.html
@@ -23,7 +23,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">hal9001</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.4.4</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.4.5</span>
       </span>
     </div>
 
@@ -84,13 +84,11 @@
 
 
       <footer><div class="copyright">
-  <p></p><p>Developed by Jeremy Coyle, Nima Hejazi, Rachael Phillips, Lars van
-der Laan, Mark van der Laan.</p>
+  <p></p><p>Developed by Jeremy Coyle, Nima Hejazi, Rachael Phillips, Lars van der Laan, Mark van der Laan.</p>
 </div>
 
 <div class="pkgdown">
-  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a>
-2.0.2.</p>
+  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.3.</p>
 </div>
 
       </footer></div>

--- a/docs/reference/cv_lasso.html
+++ b/docs/reference/cv_lasso.html
@@ -24,7 +24,7 @@ based on origami"><!-- mathjax --><script src="https://cdnjs.cloudflare.com/ajax
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">hal9001</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.4.4</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.4.5</span>
       </span>
     </div>
 
@@ -98,13 +98,11 @@ slower, but matches the <code>glmnet</code> implementation. Default <code>FALSE<
 
 
       <footer><div class="copyright">
-  <p></p><p>Developed by Jeremy Coyle, Nima Hejazi, Rachael Phillips, Lars van
-der Laan, Mark van der Laan.</p>
+  <p></p><p>Developed by Jeremy Coyle, Nima Hejazi, Rachael Phillips, Lars van der Laan, Mark van der Laan.</p>
 </div>
 
 <div class="pkgdown">
-  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a>
-2.0.2.</p>
+  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.3.</p>
 </div>
 
       </footer></div>

--- a/docs/reference/cv_lasso_early_stopping.html
+++ b/docs/reference/cv_lasso_early_stopping.html
@@ -24,7 +24,7 @@ based on origami"><!-- mathjax --><script src="https://cdnjs.cloudflare.com/ajax
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">hal9001</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.4.4</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.4.5</span>
       </span>
     </div>
 
@@ -95,13 +95,11 @@ the cross-validation procedure to select an optimal value of lambda.</p></dd>
 
 
       <footer><div class="copyright">
-  <p></p><p>Developed by Jeremy Coyle, Nima Hejazi, Rachael Phillips, Lars van
-der Laan, Mark van der Laan.</p>
+  <p></p><p>Developed by Jeremy Coyle, Nima Hejazi, Rachael Phillips, Lars van der Laan, Mark van der Laan.</p>
 </div>
 
 <div class="pkgdown">
-  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a>
-2.0.2.</p>
+  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.3.</p>
 </div>
 
       </footer></div>

--- a/docs/reference/enumerate_basis.html
+++ b/docs/reference/enumerate_basis.html
@@ -24,7 +24,7 @@ to a specified order/degree."><!-- mathjax --><script src="https://cdnjs.cloudfl
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">hal9001</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.4.4</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.4.5</span>
       </span>
     </div>
 
@@ -153,13 +153,11 @@ interaction thereof up to a pre-specified degree.</p>
 
 
       <footer><div class="copyright">
-  <p></p><p>Developed by Jeremy Coyle, Nima Hejazi, Rachael Phillips, Lars van
-der Laan, Mark van der Laan.</p>
+  <p></p><p>Developed by Jeremy Coyle, Nima Hejazi, Rachael Phillips, Lars van der Laan, Mark van der Laan.</p>
 </div>
 
 <div class="pkgdown">
-  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a>
-2.0.2.</p>
+  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.3.</p>
 </div>
 
       </footer></div>

--- a/docs/reference/enumerate_edge_basis.html
+++ b/docs/reference/enumerate_edge_basis.html
@@ -28,7 +28,7 @@ HAL basis functions at the left most value/edge of x).'><!-- mathjax --><script 
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">hal9001</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.4.4</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.4.5</span>
       </span>
     </div>
 
@@ -122,13 +122,11 @@ specified via <code>smoothness_orders</code>.</p></dd>
 
 
       <footer><div class="copyright">
-  <p></p><p>Developed by Jeremy Coyle, Nima Hejazi, Rachael Phillips, Lars van
-der Laan, Mark van der Laan.</p>
+  <p></p><p>Developed by Jeremy Coyle, Nima Hejazi, Rachael Phillips, Lars van der Laan, Mark van der Laan.</p>
 </div>
 
 <div class="pkgdown">
-  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a>
-2.0.2.</p>
+  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.3.</p>
 </div>
 
       </footer></div>

--- a/docs/reference/evaluate_basis.html
+++ b/docs/reference/evaluate_basis.html
@@ -23,7 +23,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">hal9001</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.4.4</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.4.5</span>
       </span>
     </div>
 
@@ -88,13 +88,11 @@
 
 
       <footer><div class="copyright">
-  <p></p><p>Developed by Jeremy Coyle, Nima Hejazi, Rachael Phillips, Lars van
-der Laan, Mark van der Laan.</p>
+  <p></p><p>Developed by Jeremy Coyle, Nima Hejazi, Rachael Phillips, Lars van der Laan, Mark van der Laan.</p>
 </div>
 
 <div class="pkgdown">
-  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a>
-2.0.2.</p>
+  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.3.</p>
 </div>
 
       </footer></div>

--- a/docs/reference/fit_hal.html
+++ b/docs/reference/fit_hal.html
@@ -23,7 +23,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">hal9001</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.4.4</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.4.5</span>
       </span>
     </div>
 
@@ -74,11 +74,11 @@
   smoothness_orders <span class="op">=</span> <span class="fl">1</span>,
   num_knots <span class="op">=</span> <span class="fu"><a href="num_knots_generator.html">num_knots_generator</a></span><span class="op">(</span>max_degree <span class="op">=</span> <span class="va">max_degree</span>, smoothness_orders <span class="op">=</span>
     <span class="va">smoothness_orders</span>, base_num_knots_0 <span class="op">=</span> <span class="fl">200</span>, base_num_knots_1 <span class="op">=</span> <span class="fl">50</span><span class="op">)</span>,
-  reduce_basis <span class="op">=</span> <span class="fl">1</span><span class="op">/</span><span class="fu"><a href="https://rdrr.io/r/base/MathFun.html" class="external-link">sqrt</a></span><span class="op">(</span><span class="fu"><a href="https://rdrr.io/r/base/length.html" class="external-link">length</a></span><span class="op">(</span><span class="va">Y</span><span class="op">)</span><span class="op">)</span>,
-  family <span class="op">=</span> <span class="fu"><a href="https://rdrr.io/r/base/c.html" class="external-link">c</a></span><span class="op">(</span><span class="st">"gaussian"</span>, <span class="st">"binomial"</span>, <span class="st">"poisson"</span>, <span class="st">"cox"</span><span class="op">)</span>,
+  reduce_basis <span class="op">=</span> <span class="cn">NULL</span>,
+  family <span class="op">=</span> <span class="fu"><a href="https://rdrr.io/r/base/c.html" class="external-link">c</a></span><span class="op">(</span><span class="st">"gaussian"</span>, <span class="st">"binomial"</span>, <span class="st">"poisson"</span>, <span class="st">"cox"</span>, <span class="st">"mgaussian"</span><span class="op">)</span>,
   lambda <span class="op">=</span> <span class="cn">NULL</span>,
   id <span class="op">=</span> <span class="cn">NULL</span>,
-  weights <span class="op">=</span> <span class="fu"><a href="https://rdrr.io/r/base/rep.html" class="external-link">rep</a></span><span class="op">(</span><span class="fl">1</span>, <span class="fu"><a href="https://rdrr.io/r/base/length.html" class="external-link">length</a></span><span class="op">(</span><span class="va">Y</span><span class="op">)</span><span class="op">)</span>,
+  weights <span class="op">=</span> <span class="cn">NULL</span>,
   offset <span class="op">=</span> <span class="cn">NULL</span>,
   fit_control <span class="op">=</span> <span class="fu"><a href="https://rdrr.io/r/base/list.html" class="external-link">list</a></span><span class="op">(</span>cv_select <span class="op">=</span> <span class="cn">TRUE</span>, use_min <span class="op">=</span> <span class="cn">TRUE</span>, lambda.min.ratio <span class="op">=</span> <span class="fl">1e-04</span>,
     prediction_bounds <span class="op">=</span> <span class="st">"default"</span><span class="op">)</span>,
@@ -96,7 +96,9 @@
 number of covariates that will be used to derive the design matrix of basis
 functions.</p></dd>
 <dt>Y</dt>
-<dd><p>A <code>numeric</code> vector of observations of the outcome variable.</p></dd>
+<dd><p>A <code>numeric</code> vector of observations of the outcome variable. For
+<code>family="mgaussian"</code>, <code>Y</code> is a matrix of observations of the
+outcome variables.</p></dd>
 <dt>formula</dt>
 <dd><p>A character string formula to be used in
 <code><a href="formula_hal.html">formula_hal</a></code>. See its documentation for details.</p></dd>
@@ -124,19 +126,21 @@ combinatorial explosions in the number of higher-degree and higher-order
 basis functions generated. This allows the complexity of the optimization
 problem to grow scalably. See details of <code>num_knots</code> more information.</p></dd>
 <dt>reduce_basis</dt>
-<dd><p>A <code>numeric</code> value bounded in the open unit interval
-indicating the minimum proportion of 1's in a basis function column needed
-for the basis function to be included in the procedure to fit the lasso.
-Any basis functions with a lower proportion of 1's than the cutoff will be
-removed. When <code>reduce_basis</code> is set to <code>NULL</code>, all basis
-functions are used in the lasso-fitting stage of <code>fit_hal</code>.</p></dd>
+<dd><p>Am optional <code>numeric</code> value bounded in the open
+unit interval indicating the minimum proportion of 1's in a basis function
+column needed for the basis function to be included in the procedure to fit
+the lasso. Any basis functions with a lower proportion of 1's than the
+cutoff will be removed. Defaults to 1 over the square root of the number of
+observations. Only applicable for models fit with zero-order splines, i.e.
+<code>smoothness_orders = 0</code>.</p></dd>
 <dt>family</dt>
 <dd><p>A <code>character</code> or a <code><a href="https://rdrr.io/r/stats/family.html" class="external-link">family</a></code> object
 (supported by <code><a href="https://glmnet.stanford.edu/reference/glmnet.html" class="external-link">glmnet</a></code>) specifying the error/link
 family for a generalized linear model. <code>character</code> options are limited
 to "gaussian" for fitting a standard penalized linear model, "binomial" for
 penalized logistic regression, "poisson" for penalized Poisson regression,
-and "cox" for a penalized proportional hazards model. Note that passing in
+"cox" for a penalized proportional hazards model, and "mgaussian" for
+multivariate penalized linear model. Note that passing in
 family objects leads to slower performance relative to passing in a
 character family (if supported). For example, one should set
 <code>family = "binomial"</code> instead of <code>family = binomial()</code> when
@@ -177,12 +181,13 @@ specifying the smallest value for <code>lambda</code>, as a fraction of
 for which all coefficients are zero). We've seen that not setting
 <code>lambda.min.ratio</code> can lead to no <code>lambda</code> values that fit the
 data sufficiently well.</p></li>
-<li><p><code>prediction_bounds</code>: A vector of size two that provides the lower
-and upper bounds for predictions. When
-<code>prediction_bounds = "default"</code>, the predictions are bounded between
-<code>min(Y) - sd(Y)</code> and <code>max(Y) + sd(Y)</code>. Bounding ensures that
-there is no extrapolation, and it is necessary for cross-validation
-selection and/or Super Learning.</p></li>
+<li><p><code>prediction_bounds</code>: An optional vector of size two that provides
+the lower and upper bounds predictions; not used when
+<code>family = "cox"</code>. When <code>prediction_bounds = "default"</code>, the
+predictions are bounded between <code>min(Y) - sd(Y)</code> and
+<code>max(Y) + sd(Y)</code> for each outcome (when <code>family = "mgaussian"</code>,
+each outcome can have different bounds). Bounding ensures that there is
+no extrapolation.</p></li>
 </ul></dd>
 <dt>basis_list</dt>
 <dd><p>The full set of basis functions generated from <code>X</code>.</p></dd>
@@ -276,13 +281,11 @@ in a faster runtime:</p><ul><li><p>Some good settings for little to no cost in p
 
 
       <footer><div class="copyright">
-  <p></p><p>Developed by Jeremy Coyle, Nima Hejazi, Rachael Phillips, Lars van
-der Laan, Mark van der Laan.</p>
+  <p></p><p>Developed by Jeremy Coyle, Nima Hejazi, Rachael Phillips, Lars van der Laan, Mark van der Laan.</p>
 </div>
 
 <div class="pkgdown">
-  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a>
-2.0.2.</p>
+  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.3.</p>
 </div>
 
       </footer></div>

--- a/docs/reference/formula_hal.html
+++ b/docs/reference/formula_hal.html
@@ -23,7 +23,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">hal9001</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.4.4</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.4.5</span>
       </span>
     </div>
 
@@ -91,13 +91,11 @@ When <code>NULL</code> (the default), such a variable is inherited.</p></dd>
 
 
       <footer><div class="copyright">
-  <p></p><p>Developed by Jeremy Coyle, Nima Hejazi, Rachael Phillips, Lars van
-der Laan, Mark van der Laan.</p>
+  <p></p><p>Developed by Jeremy Coyle, Nima Hejazi, Rachael Phillips, Lars van der Laan, Mark van der Laan.</p>
 </div>
 
 <div class="pkgdown">
-  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a>
-2.0.2.</p>
+  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.3.</p>
 </div>
 
       </footer></div>

--- a/docs/reference/formula_helpers.html
+++ b/docs/reference/formula_helpers.html
@@ -23,7 +23,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">hal9001</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.4.4</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.4.5</span>
       </span>
     </div>
 
@@ -86,13 +86,11 @@
 
 
       <footer><div class="copyright">
-  <p></p><p>Developed by Jeremy Coyle, Nima Hejazi, Rachael Phillips, Lars van
-der Laan, Mark van der Laan.</p>
+  <p></p><p>Developed by Jeremy Coyle, Nima Hejazi, Rachael Phillips, Lars van der Laan, Mark van der Laan.</p>
 </div>
 
 <div class="pkgdown">
-  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a>
-2.0.2.</p>
+  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.3.</p>
 </div>
 
       </footer></div>

--- a/docs/reference/h.html
+++ b/docs/reference/h.html
@@ -23,7 +23,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">hal9001</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.4.4</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.4.5</span>
       </span>
     </div>
 
@@ -145,13 +145,11 @@ can be found. Otherwise, <code>X</code> is taken from the parent environment.</p
 
 
       <footer><div class="copyright">
-  <p></p><p>Developed by Jeremy Coyle, Nima Hejazi, Rachael Phillips, Lars van
-der Laan, Mark van der Laan.</p>
+  <p></p><p>Developed by Jeremy Coyle, Nima Hejazi, Rachael Phillips, Lars van der Laan, Mark van der Laan.</p>
 </div>
 
 <div class="pkgdown">
-  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a>
-2.0.2.</p>
+  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.3.</p>
 </div>
 
       </footer></div>

--- a/docs/reference/hal9000.html
+++ b/docs/reference/hal9000.html
@@ -23,7 +23,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">hal9001</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.4.4</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.4.5</span>
       </span>
     </div>
 
@@ -77,13 +77,11 @@
 
 
       <footer><div class="copyright">
-  <p></p><p>Developed by Jeremy Coyle, Nima Hejazi, Rachael Phillips, Lars van
-der Laan, Mark van der Laan.</p>
+  <p></p><p>Developed by Jeremy Coyle, Nima Hejazi, Rachael Phillips, Lars van der Laan, Mark van der Laan.</p>
 </div>
 
 <div class="pkgdown">
-  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a>
-2.0.2.</p>
+  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.3.</p>
 </div>
 
       </footer></div>

--- a/docs/reference/hal9001.html
+++ b/docs/reference/hal9001.html
@@ -23,7 +23,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">hal9001</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.4.4</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.4.5</span>
       </span>
     </div>
 
@@ -74,13 +74,11 @@
 
 
       <footer><div class="copyright">
-  <p></p><p>Developed by Jeremy Coyle, Nima Hejazi, Rachael Phillips, Lars van
-der Laan, Mark van der Laan.</p>
+  <p></p><p>Developed by Jeremy Coyle, Nima Hejazi, Rachael Phillips, Lars van der Laan, Mark van der Laan.</p>
 </div>
 
 <div class="pkgdown">
-  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a>
-2.0.2.</p>
+  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.3.</p>
 </div>
 
       </footer></div>

--- a/docs/reference/hal_quotes.html
+++ b/docs/reference/hal_quotes.html
@@ -24,7 +24,7 @@ acclaimed epic science-fiction film "2001: A Space Odyssey" (1968).'><!-- mathja
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">hal9001</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.4.4</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.4.5</span>
       </span>
     </div>
 
@@ -83,13 +83,11 @@ acclaimed epic science-fiction film "2001: A Space Odyssey" (1968).</p>
 
 
       <footer><div class="copyright">
-  <p></p><p>Developed by Jeremy Coyle, Nima Hejazi, Rachael Phillips, Lars van
-der Laan, Mark van der Laan.</p>
+  <p></p><p>Developed by Jeremy Coyle, Nima Hejazi, Rachael Phillips, Lars van der Laan, Mark van der Laan.</p>
 </div>
 
 <div class="pkgdown">
-  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a>
-2.0.2.</p>
+  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.3.</p>
 </div>
 
       </footer></div>

--- a/docs/reference/index.html
+++ b/docs/reference/index.html
@@ -23,7 +23,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">hal9001</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.4.4</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.4.5</span>
       </span>
     </div>
 
@@ -200,13 +200,11 @@ formula object term.</p></td>
 
 
       <footer><div class="copyright">
-  <p></p><p>Developed by Jeremy Coyle, Nima Hejazi, Rachael Phillips, Lars van
-der Laan, Mark van der Laan.</p>
+  <p></p><p>Developed by Jeremy Coyle, Nima Hejazi, Rachael Phillips, Lars van der Laan, Mark van der Laan.</p>
 </div>
 
 <div class="pkgdown">
-  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a>
-2.0.2.</p>
+  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.3.</p>
 </div>
 
       </footer></div>

--- a/docs/reference/index_first_copy.html
+++ b/docs/reference/index_first_copy.html
@@ -24,7 +24,7 @@ copy of that column"><!-- mathjax --><script src="https://cdnjs.cloudflare.com/a
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">hal9001</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.4.4</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.4.5</span>
       </span>
     </div>
 
@@ -84,13 +84,11 @@ copy of that column</p>
 
 
       <footer><div class="copyright">
-  <p></p><p>Developed by Jeremy Coyle, Nima Hejazi, Rachael Phillips, Lars van
-der Laan, Mark van der Laan.</p>
+  <p></p><p>Developed by Jeremy Coyle, Nima Hejazi, Rachael Phillips, Lars van der Laan, Mark van der Laan.</p>
 </div>
 
 <div class="pkgdown">
-  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a>
-2.0.2.</p>
+  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.3.</p>
 </div>
 
       </footer></div>

--- a/docs/reference/lassi.html
+++ b/docs/reference/lassi.html
@@ -23,7 +23,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">hal9001</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.4.4</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.4.5</span>
       </span>
     </div>
 
@@ -100,13 +100,11 @@
 
 
       <footer><div class="copyright">
-  <p></p><p>Developed by Jeremy Coyle, Nima Hejazi, Rachael Phillips, Lars van
-der Laan, Mark van der Laan.</p>
+  <p></p><p>Developed by Jeremy Coyle, Nima Hejazi, Rachael Phillips, Lars van der Laan, Mark van der Laan.</p>
 </div>
 
 <div class="pkgdown">
-  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a>
-2.0.2.</p>
+  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.3.</p>
 </div>
 
       </footer></div>

--- a/docs/reference/lassi_fit_module.html
+++ b/docs/reference/lassi_fit_module.html
@@ -23,7 +23,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">hal9001</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.4.4</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.4.5</span>
       </span>
     </div>
 
@@ -74,13 +74,11 @@
 
 
       <footer><div class="copyright">
-  <p></p><p>Developed by Jeremy Coyle, Nima Hejazi, Rachael Phillips, Lars van
-der Laan, Mark van der Laan.</p>
+  <p></p><p>Developed by Jeremy Coyle, Nima Hejazi, Rachael Phillips, Lars van der Laan, Mark van der Laan.</p>
 </div>
 
 <div class="pkgdown">
-  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a>
-2.0.2.</p>
+  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.3.</p>
 </div>
 
       </footer></div>

--- a/docs/reference/lassi_origami.html
+++ b/docs/reference/lassi_origami.html
@@ -26,7 +26,7 @@ to be invoked by itself. INTERNAL USE ONLY."><!-- mathjax --><script src="https:
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">hal9001</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.4.4</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.4.5</span>
       </span>
     </div>
 
@@ -99,13 +99,11 @@ slower, but matches the <code>glmnet</code> implementation. Default <code>FALSE<
 
 
       <footer><div class="copyright">
-  <p></p><p>Developed by Jeremy Coyle, Nima Hejazi, Rachael Phillips, Lars van
-der Laan, Mark van der Laan.</p>
+  <p></p><p>Developed by Jeremy Coyle, Nima Hejazi, Rachael Phillips, Lars van der Laan, Mark van der Laan.</p>
 </div>
 
 <div class="pkgdown">
-  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a>
-2.0.2.</p>
+  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.3.</p>
 </div>
 
       </footer></div>

--- a/docs/reference/lassi_predict.html
+++ b/docs/reference/lassi_predict.html
@@ -23,7 +23,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">hal9001</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.4.4</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.4.5</span>
       </span>
     </div>
 
@@ -86,13 +86,11 @@
 
 
       <footer><div class="copyright">
-  <p></p><p>Developed by Jeremy Coyle, Nima Hejazi, Rachael Phillips, Lars van
-der Laan, Mark van der Laan.</p>
+  <p></p><p>Developed by Jeremy Coyle, Nima Hejazi, Rachael Phillips, Lars van der Laan, Mark van der Laan.</p>
 </div>
 
 <div class="pkgdown">
-  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a>
-2.0.2.</p>
+  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.3.</p>
 </div>
 
       </footer></div>

--- a/docs/reference/make_basis_list.html
+++ b/docs/reference/make_basis_list.html
@@ -24,7 +24,7 @@ basis function is a list"><!-- mathjax --><script src="https://cdnjs.cloudflare.
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">hal9001</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.4.4</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.4.5</span>
       </span>
     </div>
 
@@ -93,13 +93,11 @@ equals cols.length() and each basis function is a list(cols, cutoffs).</p>
 
 
       <footer><div class="copyright">
-  <p></p><p>Developed by Jeremy Coyle, Nima Hejazi, Rachael Phillips, Lars van
-der Laan, Mark van der Laan.</p>
+  <p></p><p>Developed by Jeremy Coyle, Nima Hejazi, Rachael Phillips, Lars van der Laan, Mark van der Laan.</p>
 </div>
 
 <div class="pkgdown">
-  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a>
-2.0.2.</p>
+  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.3.</p>
 </div>
 
       </footer></div>

--- a/docs/reference/make_copy_map.html
+++ b/docs/reference/make_copy_map.html
@@ -23,7 +23,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">hal9001</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.4.4</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.4.5</span>
       </span>
     </div>
 
@@ -113,13 +113,11 @@ functions that are identical in the training set.</p>
 
 
       <footer><div class="copyright">
-  <p></p><p>Developed by Jeremy Coyle, Nima Hejazi, Rachael Phillips, Lars van
-der Laan, Mark van der Laan.</p>
+  <p></p><p>Developed by Jeremy Coyle, Nima Hejazi, Rachael Phillips, Lars van der Laan, Mark van der Laan.</p>
 </div>
 
 <div class="pkgdown">
-  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a>
-2.0.2.</p>
+  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.3.</p>
 </div>
 
       </footer></div>

--- a/docs/reference/make_design_matrix.html
+++ b/docs/reference/make_design_matrix.html
@@ -24,7 +24,7 @@ basis functions in argument blist"><!-- mathjax --><script src="https://cdnjs.cl
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">hal9001</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.4.4</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.4.5</span>
       </span>
     </div>
 
@@ -118,13 +118,11 @@ corresponding to the design matrix in a zero-order highly adaptive lasso.</p>
 
 
       <footer><div class="copyright">
-  <p></p><p>Developed by Jeremy Coyle, Nima Hejazi, Rachael Phillips, Lars van
-der Laan, Mark van der Laan.</p>
+  <p></p><p>Developed by Jeremy Coyle, Nima Hejazi, Rachael Phillips, Lars van der Laan, Mark van der Laan.</p>
 </div>
 
 <div class="pkgdown">
-  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a>
-2.0.2.</p>
+  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.3.</p>
 </div>
 
       </footer></div>

--- a/docs/reference/make_reduced_basis_map.html
+++ b/docs/reference/make_reduced_basis_map.html
@@ -25,7 +25,7 @@ which to discard) based on the proportion of 1's (observations, i.e.,
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">hal9001</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.4.4</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.4.5</span>
       </span>
     </div>
 
@@ -101,13 +101,11 @@ a zero).</p>
 
 
       <footer><div class="copyright">
-  <p></p><p>Developed by Jeremy Coyle, Nima Hejazi, Rachael Phillips, Lars van
-der Laan, Mark van der Laan.</p>
+  <p></p><p>Developed by Jeremy Coyle, Nima Hejazi, Rachael Phillips, Lars van der Laan, Mark van der Laan.</p>
 </div>
 
 <div class="pkgdown">
-  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a>
-2.0.2.</p>
+  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.3.</p>
 </div>
 
       </footer></div>

--- a/docs/reference/meets_basis.html
+++ b/docs/reference/meets_basis.html
@@ -24,7 +24,7 @@ cols and cutoffs for a given row of X"><!-- mathjax --><script src="https://cdnj
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">hal9001</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.4.4</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.4.5</span>
       </span>
     </div>
 
@@ -92,13 +92,11 @@ cols and cutoffs for a given row of X</p>
 
 
       <footer><div class="copyright">
-  <p></p><p>Developed by Jeremy Coyle, Nima Hejazi, Rachael Phillips, Lars van
-der Laan, Mark van der Laan.</p>
+  <p></p><p>Developed by Jeremy Coyle, Nima Hejazi, Rachael Phillips, Lars van der Laan, Mark van der Laan.</p>
 </div>
 
 <div class="pkgdown">
-  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a>
-2.0.2.</p>
+  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.3.</p>
 </div>
 
       </footer></div>

--- a/docs/reference/num_knots_generator.html
+++ b/docs/reference/num_knots_generator.html
@@ -26,7 +26,7 @@ interactions and the smoothness orders."><!-- mathjax --><script src="https://cd
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">hal9001</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.4.4</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.4.5</span>
       </span>
     </div>
 
@@ -104,13 +104,11 @@ the basis function.</p></dd>
 
 
       <footer><div class="copyright">
-  <p></p><p>Developed by Jeremy Coyle, Nima Hejazi, Rachael Phillips, Lars van
-der Laan, Mark van der Laan.</p>
+  <p></p><p>Developed by Jeremy Coyle, Nima Hejazi, Rachael Phillips, Lars van der Laan, Mark van der Laan.</p>
 </div>
 
 <div class="pkgdown">
-  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a>
-2.0.2.</p>
+  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.3.</p>
 </div>
 
       </footer></div>

--- a/docs/reference/plus-.formula_hal9001.html
+++ b/docs/reference/plus-.formula_hal9001.html
@@ -26,7 +26,7 @@ formula object term."><!-- mathjax --><script src="https://cdnjs.cloudflare.com/
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">hal9001</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.4.4</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.4.5</span>
       </span>
     </div>
 
@@ -90,13 +90,11 @@ formula object term.</p>
 
 
       <footer><div class="copyright">
-  <p></p><p>Developed by Jeremy Coyle, Nima Hejazi, Rachael Phillips, Lars van
-der Laan, Mark van der Laan.</p>
+  <p></p><p>Developed by Jeremy Coyle, Nima Hejazi, Rachael Phillips, Lars van der Laan, Mark van der Laan.</p>
 </div>
 
 <div class="pkgdown">
-  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a>
-2.0.2.</p>
+  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.3.</p>
 </div>
 
       </footer></div>

--- a/docs/reference/predict.SL.hal9001.html
+++ b/docs/reference/predict.SL.hal9001.html
@@ -23,7 +23,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">hal9001</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.4.4</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.4.5</span>
       </span>
     </div>
 
@@ -91,13 +91,11 @@
 
 
       <footer><div class="copyright">
-  <p></p><p>Developed by Jeremy Coyle, Nima Hejazi, Rachael Phillips, Lars van
-der Laan, Mark van der Laan.</p>
+  <p></p><p>Developed by Jeremy Coyle, Nima Hejazi, Rachael Phillips, Lars van der Laan, Mark van der Laan.</p>
 </div>
 
 <div class="pkgdown">
-  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a>
-2.0.2.</p>
+  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.3.</p>
 </div>
 
       </footer></div>

--- a/docs/reference/predict.hal9001.html
+++ b/docs/reference/predict.hal9001.html
@@ -23,7 +23,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">hal9001</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.4.4</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.4.5</span>
       </span>
     </div>
 
@@ -72,7 +72,6 @@
   new_X_unpenalized <span class="op">=</span> <span class="cn">NULL</span>,
   offset <span class="op">=</span> <span class="cn">NULL</span>,
   type <span class="op">=</span> <span class="fu"><a href="https://rdrr.io/r/base/c.html" class="external-link">c</a></span><span class="op">(</span><span class="st">"response"</span>, <span class="st">"link"</span><span class="op">)</span>,
-  p_reserve <span class="op">=</span> <span class="fl">0.75</span>,
   <span class="va">...</span>
 <span class="op">)</span></code></pre></div>
     </div>
@@ -96,11 +95,6 @@ observations as <code>new_data</code>.</p></dd>
 <dt>type</dt>
 <dd><p>Either "response" for predictions of the response, or "link" for
 un-transformed predictions (on the scale of the link function).</p></dd>
-<dt>p_reserve</dt>
-<dd><p>Sparse matrix pre-allocation proportion, which is the
-anticipated proportion of 1's in the design matrix. Default value is
-recommended in most settings. If a dense design matrix is expected, it
-would be useful to set <code>p_reserve</code> to a higher value.</p></dd>
 <dt>...</dt>
 <dd><p>Additional arguments passed to <code>predict</code> as necessary.</p></dd>
 </dl></div>
@@ -135,13 +129,11 @@ selected by cross-validation.</p>
 
 
       <footer><div class="copyright">
-  <p></p><p>Developed by Jeremy Coyle, Nima Hejazi, Rachael Phillips, Lars van
-der Laan, Mark van der Laan.</p>
+  <p></p><p>Developed by Jeremy Coyle, Nima Hejazi, Rachael Phillips, Lars van der Laan, Mark van der Laan.</p>
 </div>
 
 <div class="pkgdown">
-  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a>
-2.0.2.</p>
+  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.3.</p>
 </div>
 
       </footer></div>

--- a/docs/reference/predict.lassi.html
+++ b/docs/reference/predict.lassi.html
@@ -23,7 +23,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">hal9001</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.4.4</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.4.5</span>
       </span>
     </div>
 
@@ -87,13 +87,11 @@
 
 
       <footer><div class="copyright">
-  <p></p><p>Developed by Jeremy Coyle, Nima Hejazi, Rachael Phillips, Lars van
-der Laan, Mark van der Laan.</p>
+  <p></p><p>Developed by Jeremy Coyle, Nima Hejazi, Rachael Phillips, Lars van der Laan, Mark van der Laan.</p>
 </div>
 
 <div class="pkgdown">
-  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a>
-2.0.2.</p>
+  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.3.</p>
 </div>
 
       </footer></div>

--- a/docs/reference/print.formula_hal9001.html
+++ b/docs/reference/print.formula_hal9001.html
@@ -23,7 +23,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">hal9001</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.4.4</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.4.5</span>
       </span>
     </div>
 
@@ -85,13 +85,11 @@
 
 
       <footer><div class="copyright">
-  <p></p><p>Developed by Jeremy Coyle, Nima Hejazi, Rachael Phillips, Lars van
-der Laan, Mark van der Laan.</p>
+  <p></p><p>Developed by Jeremy Coyle, Nima Hejazi, Rachael Phillips, Lars van der Laan, Mark van der Laan.</p>
 </div>
 
 <div class="pkgdown">
-  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a>
-2.0.2.</p>
+  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.3.</p>
 </div>
 
       </footer></div>

--- a/docs/reference/print.summary.hal9001.html
+++ b/docs/reference/print.summary.hal9001.html
@@ -23,7 +23,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">hal9001</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.4.4</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.4.5</span>
       </span>
     </div>
 
@@ -87,13 +87,11 @@
 
 
       <footer><div class="copyright">
-  <p></p><p>Developed by Jeremy Coyle, Nima Hejazi, Rachael Phillips, Lars van
-der Laan, Mark van der Laan.</p>
+  <p></p><p>Developed by Jeremy Coyle, Nima Hejazi, Rachael Phillips, Lars van der Laan, Mark van der Laan.</p>
 </div>
 
 <div class="pkgdown">
-  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a>
-2.0.2.</p>
+  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.3.</p>
 </div>
 
       </footer></div>

--- a/docs/reference/quantizer.html
+++ b/docs/reference/quantizer.html
@@ -23,7 +23,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">hal9001</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.4.4</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.4.5</span>
       </span>
     </div>
 
@@ -85,13 +85,11 @@
 
 
       <footer><div class="copyright">
-  <p></p><p>Developed by Jeremy Coyle, Nima Hejazi, Rachael Phillips, Lars van
-der Laan, Mark van der Laan.</p>
+  <p></p><p>Developed by Jeremy Coyle, Nima Hejazi, Rachael Phillips, Lars van der Laan, Mark van der Laan.</p>
 </div>
 
 <div class="pkgdown">
-  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a>
-2.0.2.</p>
+  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.3.</p>
 </div>
 
       </footer></div>

--- a/docs/reference/squash_hal_fit.html
+++ b/docs/reference/squash_hal_fit.html
@@ -23,7 +23,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">hal9001</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.4.4</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.4.5</span>
       </span>
     </div>
 
@@ -104,13 +104,11 @@ to zero removed.</p>
 
 
       <footer><div class="copyright">
-  <p></p><p>Developed by Jeremy Coyle, Nima Hejazi, Rachael Phillips, Lars van
-der Laan, Mark van der Laan.</p>
+  <p></p><p>Developed by Jeremy Coyle, Nima Hejazi, Rachael Phillips, Lars van der Laan, Mark van der Laan.</p>
 </div>
 
 <div class="pkgdown">
-  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a>
-2.0.2.</p>
+  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.3.</p>
 </div>
 
       </footer></div>

--- a/docs/reference/summary.hal9001.html
+++ b/docs/reference/summary.hal9001.html
@@ -23,7 +23,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">hal9001</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.4.4</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.4.5</span>
       </span>
     </div>
 
@@ -136,13 +136,11 @@ package (or similar). Here's an example:
 
 
       <footer><div class="copyright">
-  <p></p><p>Developed by Jeremy Coyle, Nima Hejazi, Rachael Phillips, Lars van
-der Laan, Mark van der Laan.</p>
+  <p></p><p>Developed by Jeremy Coyle, Nima Hejazi, Rachael Phillips, Lars van der Laan, Mark van der Laan.</p>
 </div>
 
 <div class="pkgdown">
-  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a>
-2.0.2.</p>
+  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.3.</p>
 </div>
 
       </footer></div>

--- a/man/fit_hal.Rd
+++ b/man/fit_hal.Rd
@@ -120,11 +120,12 @@ for which all coefficients are zero). We've seen that not setting
 \code{lambda.min.ratio} can lead to no \code{lambda} values that fit the
 data sufficiently well.
 \item \code{prediction_bounds}: An optional vector of size two that provides
-the lower and upper bounds for predictions. When
-\code{prediction_bounds = "default"}, the predictions are bounded between
-\code{min(Y) - sd(Y)} and \code{max(Y) + sd(Y)}. Bounding ensures that
-there is no extrapolation, and it is necessary for cross-validation
-selection and/or Super Learning.
+the lower and upper bounds predictions; not used when
+\code{family = "cox"}. When \code{prediction_bounds = "default"}, the
+predictions are bounded between \code{min(Y) - sd(Y)} and
+\code{max(Y) + sd(Y)} for each outcome (when \code{family = "mgaussian"},
+each outcome can have different bounds). Bounding ensures that there is
+no extrapolation.
 }}
 
 \item{basis_list}{The full set of basis functions generated from \code{X}.}

--- a/man/fit_hal.Rd
+++ b/man/fit_hal.Rd
@@ -13,11 +13,11 @@ fit_hal(
   smoothness_orders = 1,
   num_knots = num_knots_generator(max_degree = max_degree, smoothness_orders =
     smoothness_orders, base_num_knots_0 = 200, base_num_knots_1 = 50),
-  reduce_basis = 1/sqrt(length(Y)),
-  family = c("gaussian", "binomial", "poisson", "cox"),
+  reduce_basis = NULL,
+  family = c("gaussian", "binomial", "poisson", "cox", "mgaussian"),
   lambda = NULL,
   id = NULL,
-  weights = rep(1, length(Y)),
+  weights = NULL,
   offset = NULL,
   fit_control = list(cv_select = TRUE, use_min = TRUE, lambda.min.ratio = 1e-04,
     prediction_bounds = "default"),
@@ -32,7 +32,9 @@ fit_hal(
 number of covariates that will be used to derive the design matrix of basis
 functions.}
 
-\item{Y}{A \code{numeric} vector of observations of the outcome variable.}
+\item{Y}{A \code{numeric} vector of observations of the outcome variable. For
+\code{family="mgaussian"}, \code{Y} is a matrix of observations of the
+outcome variables.}
 
 \item{formula}{A character string formula to be used in
 \code{\link{formula_hal}}. See its documentation for details.}
@@ -60,19 +62,21 @@ combinatorial explosions in the number of higher-degree and higher-order
 basis functions generated. This allows the complexity of the optimization
 problem to grow scalably. See details of \code{num_knots} more information.}
 
-\item{reduce_basis}{A \code{numeric} value bounded in the open unit interval
-indicating the minimum proportion of 1's in a basis function column needed
-for the basis function to be included in the procedure to fit the lasso.
-Any basis functions with a lower proportion of 1's than the cutoff will be
-removed. When \code{reduce_basis} is set to \code{NULL}, all basis
-functions are used in the lasso-fitting stage of \code{fit_hal}.}
+\item{reduce_basis}{Am optional \code{numeric} value bounded in the open
+unit interval indicating the minimum proportion of 1's in a basis function
+column needed for the basis function to be included in the procedure to fit
+the lasso. Any basis functions with a lower proportion of 1's than the
+cutoff will be removed. Defaults to 1 over the square root of the number of
+observations. Only applicable for models fit with zero-order splines, i.e.
+\code{smoothness_orders = 0}.}
 
 \item{family}{A \code{character} or a \code{\link[stats]{family}} object
 (supported by \code{\link[glmnet]{glmnet}}) specifying the error/link
 family for a generalized linear model. \code{character} options are limited
 to "gaussian" for fitting a standard penalized linear model, "binomial" for
 penalized logistic regression, "poisson" for penalized Poisson regression,
-and "cox" for a penalized proportional hazards model. Note that passing in
+"cox" for a penalized proportional hazards model, and "mgaussian" for
+multivariate penalized linear model. Note that passing in
 family objects leads to slower performance relative to passing in a
 character family (if supported). For example, one should set
 \code{family = "binomial"} instead of \code{family = binomial()} when
@@ -115,8 +119,8 @@ specifying the smallest value for \code{lambda}, as a fraction of
 for which all coefficients are zero). We've seen that not setting
 \code{lambda.min.ratio} can lead to no \code{lambda} values that fit the
 data sufficiently well.
-\item \code{prediction_bounds}: A vector of size two that provides the lower
-and upper bounds for predictions. When
+\item \code{prediction_bounds}: An optional vector of size two that provides
+the lower and upper bounds for predictions. When
 \code{prediction_bounds = "default"}, the predictions are bounded between
 \code{min(Y) - sd(Y)} and \code{max(Y) + sd(Y)}. Bounding ensures that
 there is no extrapolation, and it is necessary for cross-validation

--- a/man/predict.hal9001.Rd
+++ b/man/predict.hal9001.Rd
@@ -10,7 +10,6 @@
   new_X_unpenalized = NULL,
   offset = NULL,
   type = c("response", "link"),
-  p_reserve = 0.75,
   ...
 )
 }
@@ -31,11 +30,6 @@ observations as \code{new_data}.}
 
 \item{type}{Either "response" for predictions of the response, or "link" for
 un-transformed predictions (on the scale of the link function).}
-
-\item{p_reserve}{Sparse matrix pre-allocation proportion, which is the
-anticipated proportion of 1's in the design matrix. Default value is
-recommended in most settings. If a dense design matrix is expected, it
-would be useful to set \code{p_reserve} to a higher value.}
 
 \item{...}{Additional arguments passed to \code{predict} as necessary.}
 }

--- a/tests/testthat/test-general_families.R
+++ b/tests/testthat/test-general_families.R
@@ -70,3 +70,12 @@ test_that("Error when prediction_bounds is incorrectly formatted", {
   fit_control <- list(prediction_bounds = 9)
   expect_error(fit_hal(X = x, Y = y, fit_control = fit_control))
 })
+
+test_that("Message when standardize set to TRUE", {
+  fit_control <- list(standardize = TRUE)
+  expect_message(fit_hal(X = x, Y = y, fit_control = fit_control))
+})
+
+test_that("Warning when reduce_basis without zero-order smoothness", {
+  expect_warning(fit_hal(X = x, Y = y, reduce_basis = 0.95))
+})

--- a/tests/testthat/test-general_families.R
+++ b/tests/testthat/test-general_families.R
@@ -67,6 +67,6 @@ test_that("MSE for logistic regression close to logistic family object pred", {
 })
 
 test_that("Error when prediction_bounds is incorrectly formatted", {
-  fit_control <- list(prediction_bounds = "kitty")
+  fit_control <- list(prediction_bounds = 9)
   expect_error(fit_hal(X = x, Y = y, fit_control = fit_control))
 })

--- a/tests/testthat/test-hal_binomial.R
+++ b/tests/testthat/test-hal_binomial.R
@@ -51,7 +51,7 @@ test_that("Prediction bounds respected when numeric vector supplied", {
 })
 
 test_that("Check of prediction_bounds formatting errors", {
-  kitty_fit_control <- list(prediction_bounds = "kitty")
+  kitty_fit_control <- list(prediction_bounds = 9)
   expect_error(
     fit_hal(X = x, Y = y, family = "binomial", fit_control = kitty_fit_control)
   )

--- a/tests/testthat/test-hal_multivariate.R
+++ b/tests/testthat/test-hal_multivariate.R
@@ -10,7 +10,7 @@ hal_fit <- fit_hal(
   return_x_basis = TRUE
 )
 hal_summary <- summary(hal_fit)
-
+print(hal_summary, length = 2)
 test_that("HAL and glmnet predictions match for multivariate outcome", {
   # get hal preds
   hal_pred <- predict(hal_fit, new_data = MultiGaussianExample$x)

--- a/tests/testthat/test-hal_multivariate.R
+++ b/tests/testthat/test-hal_multivariate.R
@@ -9,8 +9,7 @@ hal_fit <- fit_hal(
   X = MultiGaussianExample$x, Y = MultiGaussianExample$y, family = "mgaussian",
   return_x_basis = TRUE
 )
-hal_summary <- summary(hal_fit)
-print(hal_summary, length = 2)
+
 test_that("HAL and glmnet predictions match for multivariate outcome", {
   # get hal preds
   hal_pred <- predict(hal_fit, new_data = MultiGaussianExample$x)
@@ -26,10 +25,12 @@ test_that("HAL and glmnet predictions match for multivariate outcome", {
 })
 
 test_that("HAL summarizes coefs for each multivariate outcome prediction", {
+  hal_summary <- summary(hal_fit)
   expect_equal(ncol(MultiGaussianExample$y), length(hal_summary))
 })
 
 test_that("HAL summarizes coefs appropriately for multivariate outcome", {
+  hal_summary <- summary(hal_fit)
   # this checks intercept matches
   lapply(seq_along(hal_summary), function(i){
     expect_equal(hal_fit$coefs[[i]][1,], as.numeric(hal_summary[[i]]$table[1,1]))
@@ -40,4 +41,11 @@ test_that("Error when prediction_bounds is incorrectly formatted", {
   fit_control <- list(prediction_bounds = 9)
   expect_error(fit_hal(X = MultiGaussianExample$x, Y = MultiGaussianExample$y,
                        family = "mgaussian", fit_control = fit_control))
+})
+
+
+test_that("HAL summary for multivariate outcome predictions prints", {
+  hal_summary <- summary(hal_fit)
+  expect_output(print(hal_summary, length = 2))
+  expect_output(print(hal_summary))
 })

--- a/tests/testthat/test-hal_multivariate.R
+++ b/tests/testthat/test-hal_multivariate.R
@@ -1,0 +1,29 @@
+context("Multivariate outcome prediction with HAL")
+
+library(glmnet)
+data(MultiGaussianExample)
+
+# get hal fit
+set.seed(74296)
+hal_fit <- fit_hal(
+  X = MultiGaussianExample$x, Y = MultiGaussianExample$y, family = "mgaussian",
+  return_x_basis = TRUE
+)
+
+test_that("HAL and glmnet predictions match for multivariate outcome", {
+  # get hal preds
+  hal_pred <- predict(hal_fit, new_data = MultiGaussianExample$x)
+  # get glmnet preds
+  set.seed(74296)
+  glmnet_fit <- cv.glmnet(x = hal_fit$x_basis, y = MultiGaussianExample$y,
+                          family = "mgaussian", standardize = FALSE,
+                          lambda.min.ratio = 1e-4)
+  glmnet_pred <- predict(glmnet_fit, hal_fit$x_basis, s = hal_fit$lambda_star)[,,1]
+  # test equivalence
+  colnames(glmnet_pred) <- colnames(hal_pred)
+  expect_equivalent(glmnet_pred, hal_pred)
+})
+
+# test_that("HAL summary works for multivariate outcome prediction", {
+#   TODO
+# })

--- a/tests/testthat/test-hal_multivariate.R
+++ b/tests/testthat/test-hal_multivariate.R
@@ -9,6 +9,7 @@ hal_fit <- fit_hal(
   X = MultiGaussianExample$x, Y = MultiGaussianExample$y, family = "mgaussian",
   return_x_basis = TRUE
 )
+hal_summary <- summary(hal_fit)
 
 test_that("HAL and glmnet predictions match for multivariate outcome", {
   # get hal preds
@@ -24,6 +25,19 @@ test_that("HAL and glmnet predictions match for multivariate outcome", {
   expect_equivalent(glmnet_pred, hal_pred)
 })
 
-# test_that("HAL summary works for multivariate outcome prediction", {
-#   TODO
-# })
+test_that("HAL summarizes coefs for each multivariate outcome prediction", {
+  expect_equal(ncol(MultiGaussianExample$y), length(hal_summary))
+})
+
+test_that("HAL summarizes coefs appropriately for multivariate outcome", {
+  # this checks intercept matches
+  lapply(seq_along(hal_summary), function(i){
+    expect_equal(hal_fit$coefs[[i]][1,], as.numeric(hal_summary[[i]]$table[1,1]))
+  })
+})
+
+test_that("Error when prediction_bounds is incorrectly formatted", {
+  fit_control <- list(prediction_bounds = 9)
+  expect_error(fit_hal(X = MultiGaussianExample$x, Y = MultiGaussianExample$y,
+                       family = "mgaussian", fit_control = fit_control))
+})

--- a/tests/testthat/test-hal_multivariate.R
+++ b/tests/testthat/test-hal_multivariate.R
@@ -9,6 +9,7 @@ hal_fit <- fit_hal(
   X = MultiGaussianExample$x, Y = MultiGaussianExample$y, family = "mgaussian",
   return_x_basis = TRUE
 )
+hal_summary <- summary(hal_fit)
 
 test_that("HAL and glmnet predictions match for multivariate outcome", {
   # get hal preds
@@ -25,12 +26,10 @@ test_that("HAL and glmnet predictions match for multivariate outcome", {
 })
 
 test_that("HAL summarizes coefs for each multivariate outcome prediction", {
-  hal_summary <- summary(hal_fit)
   expect_equal(ncol(MultiGaussianExample$y), length(hal_summary))
 })
 
 test_that("HAL summarizes coefs appropriately for multivariate outcome", {
-  hal_summary <- summary(hal_fit)
   # this checks intercept matches
   lapply(seq_along(hal_summary), function(i){
     expect_equal(hal_fit$coefs[[i]][1,], as.numeric(hal_summary[[i]]$table[1,1]))
@@ -43,9 +42,10 @@ test_that("Error when prediction_bounds is incorrectly formatted", {
                        family = "mgaussian", fit_control = fit_control))
 })
 
-
 test_that("HAL summary for multivariate outcome predictions prints", {
-  hal_summary <- summary(hal_fit)
+  hal_summary2 <- summary(hal_fit, only_nonzero_coefs = FALSE)
   expect_output(print(hal_summary, length = 2))
   expect_output(print(hal_summary))
+  expect_output(print(hal_summary2, length = 2))
+  expect_output(print(hal_summary2))
 })

--- a/tests/testthat/test-sl_ecpolley.R
+++ b/tests/testthat/test-sl_ecpolley.R
@@ -40,8 +40,6 @@ sl <- SuperLearner(
   Y = y, X = x, SL.lib = c("SL.mean", "SL.hal9001"),
   cvControl = list(validRows = hal_sl$validRows)
 )
-pred_sl_train <- as.numeric(predict(sl, newX = x)$pred)
-pred_sl_test <- as.numeric(predict(sl, newX = test_x)$pred)
 
 # test for HAL vs. SL-HAL: outputs are the same length
 test_that("HAL and SuperLearner-HAL produce results of same shape", {
@@ -52,6 +50,7 @@ test_that("HAL and SuperLearner-HAL produce results of same shape", {
 # test of MSEs being close: SL-HAL and SL dominated by HAL should be very close
 # (hence the rather low tolerance, esp. given an additive scale)
 test_that("HAL dominates other algorithms when used in SuperLearner", {
+  pred_sl_test <- as.numeric(predict(sl, newX = test_x)$pred)
   expect_equal(
     mse(pred_sl_test, test_y),
     expected = mse(pred_hal_sl_test, test_y),


### PR DESCRIPTION
Add support for HAL to consider multivariate outcome predictions, i.e., glmnet fits with `family = "mgaussian"`