### PR TITLE
Update make_basis.R

### DIFF
--- a/.github/workflows/R-CMD-check.yml
+++ b/.github/workflows/R-CMD-check.yml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Setup R
-        uses: r-lib/actions/setup-r@master
+        uses: r-lib/actions/setup-r@v2
         with:
           r-version: ${{ matrix.config.r }}
 

--- a/R/make_basis.R
+++ b/R/make_basis.R
@@ -327,7 +327,7 @@ quantizer <- function(X, bins) {
 
     p <- max(1 - (20 / nrow(X)), 0.98)
     quants <- seq(0, p, length.out = bins)
-    q <- stats::quantile(x, quants)
+    q <- unique(stats::quantile(x, quants, type = 1))
     nearest <- findInterval(x, q)
     x <- q[nearest]
     return(x)

--- a/R/make_basis.R
+++ b/R/make_basis.R
@@ -328,7 +328,8 @@ quantizer <- function(X, bins) {
     p <- max(1 - (20 / nrow(X)), 0.98)
     quants <- seq(0, p, length.out = bins)
     q <- unique(stats::quantile(x, quants, type = 1))
-    nearest <- findInterval(x, q)
+    # NOTE: all.inside must be FALSE or else all binary variables are mapped to zero.
+    nearest <- findInterval(x, q, all.inside = FALSE)
     x <- q[nearest]
     return(x)
   }


### PR DESCRIPTION
Minor change

When using num_knots to bin data into quantiles, default quantile() function was used. This leads to knot points that may not be observed in data.

Now changes to quantile(type = 1), so that all knots are data points.